### PR TITLE
Add propagation of badflag with .= (Ops::assgn) for sf.net bug 3543056.

### DIFF
--- a/Basic/Ops/ops.pd
+++ b/Basic/Ops/ops.pd
@@ -407,14 +407,26 @@ sub PDL::log10 {
 #
 pp_def(
        'assgn',
-#       HandleBad => 1,
+       HandleBad => 1,
        Pars => 'a(); [o]b();',
        Code =>
        '$b() = $a();',
-#       BadCode =>
-#       'if ( $ISBAD(a()) ) { $SETBAD(b()); } else { $b() = $a(); }',
+       BadCode =>
+       'if ( $ISBAD(a()) ) { $SETBAD(b()); } else { $b() = $a(); }',
        Doc =>
 'Plain numerical assignment. This is used to implement the ".=" operator',
+		BadDoc =>
+'If C<a> is a child piddle (e.g., the result of a slice) and bad values are generated in C<b>,
+the bad value flag is set in C<b>, but it is B<NOT> automatically propagated back to the parent of C<a>.
+The following idiom ensures that the badflag is propagated back to the parent of C<a>:
+
+ $pdl->slice(":,(1)") .= PDL::Bad_aware_func();
+ $pdl->badflag(1);
+ $pdl->check_badflag();
+
+This is unnecessary if $pdl->badflag is known to be 1 before the slice is performed.
+
+See http://pdl.perl.org/PDLdocs/BadValues.html#dataflow_of_the_badflag for details.'
 ); # pp_def assgn
 
 pp_def('ipow',

--- a/t/ops.t
+++ b/t/ops.t
@@ -1,4 +1,4 @@
-use Test::More tests => 62;
+use Test::More tests => 63;
 use PDL::LiteF;
 use Config;
 kill INT,$$ if $ENV{UNDER_DEBUGGER}; # Useful for debugging.
@@ -246,3 +246,15 @@ SKIP:
 
 is(~pdl(1,2,3)              ."", '[-2 -3 -4]', 'bitwise negation');
 is((pdl(1,2,3) ^ pdl(4,5,6))."", '[5 7 5]'   , 'bitwise xor'     );
+
+SKIP: {
+skip 'No BADVAL', 1 if !$PDL::Config{WITH_BADVAL};
+# Check badflag propagation with .= (Ops::assgn) sf.net bug 3543056
+$a = sequence(10);
+$b = sequence(5);
+$b->inplace->setvaltobad(3);
+$a->slice('0:4') .= $b;
+$a->badflag(1);
+$a->check_badflag();
+ok($a->badflag == 1 && $a->nbad == 1, 'badflag propagation with .=');
+}


### PR DESCRIPTION
Rebased version of #2. Passes tests.
