### PR TITLE
Travis-CI: use perl Makefile.PL directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,11 @@ before_install:
   - build-perl
   - perl -V
   - cpanm --quiet --notest ExtUtils::F77 Term::ReadLine::Gnu PGPLOT # do not need tests
+  - cpanm --quiet --notest Devel::CheckLib # specify this now because this is a CONFIGURE_REQUIRES for author-side
   - cpanm --force --verbose ExtUtils::ParseXS # we install the latest ExtUtils::ParseXS
-  - build-dist
-  - cd $BUILD_DIR             # $BUILD_DIR is set by the build-dist command
+  - cpanm --installdeps --notest .
+  - perl Makefile.PL          # instead of the helper's build-dist
 install:
-  - cpan-install --deps       # installs prereqs, including recommends
   - cpan-install --coverage   # installs converage prereqs, if enabled
   - prove t/00-report-prereqs.t t/01-checkmanifest.t
   # SYSTEM_CORES set by travis-perl-helpers


### PR DESCRIPTION
The Travis-CI helper's `build-dist` command uses Perl 5.20 for running
every build run. This simulates a module author releasing a dist for
CPAN with `META.*` files.

By switching that out and running `Makefile.PL` directly, the run uses
the Perl version specific to that run, but it also becomes necessary to
install the `CONFIGURE_REQUIRES` requirements beforehand because the
`META.*` files are not generated yet.
