### PR TITLE
Travis-CI: set SPLIT_BUILD to false to use the run's version of Perl for configure-time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,9 @@ before_install:
   - build-perl
   - perl -V
   - cpanm --quiet --notest ExtUtils::F77 Term::ReadLine::Gnu PGPLOT # do not need tests
+  - cpanm --quiet --notest Devel::CheckLib # specify this now because this is a CONFIGURE_REQUIRES for author-side
   - cpanm --force --verbose ExtUtils::ParseXS # we install the latest ExtUtils::ParseXS
-  - build-dist
+  - SPLIT_BUILD=0 build-dist
   - cd $BUILD_DIR             # $BUILD_DIR is set by the build-dist command
 install:
   - cpan-install --deps       # installs prereqs, including recommends


### PR DESCRIPTION
By default, the Travis-CI helper's `build-dist` command uses Perl 5.20
for running every build run. This simulates a module author releasing a
dist for CPAN with `META.*` files.

By switching that out and running `Makefile.PL` directly, the run uses
the Perl version specific to that run, but it also becomes necessary to
install the `CONFIGURE_REQUIRES` requirements beforehand because the
`META.*` files are not generated yet.