### PR TITLE
Make Filter::Util::Call the default engine for PDL::NiceSlice

### DIFF
--- a/Basic/SourceFilter/NiceSlice.pm
+++ b/Basic/SourceFilter/NiceSlice.pm
@@ -5,9 +5,9 @@ BEGIN {
       'Module::Compile'     => 'PDL/NiceSlice/ModuleCompile.pm',
    );  # to validate names
 
-   $PDL::NiceSlice::engine = $engine_ok{'Filter::Simple'};  # default engine type
+   ## $PDL::NiceSlice::engine = $engine_ok{'Filter::Simple'};  # default engine type
    ## TODO: Add configuration argument to perldl.conf
-   ## $PDL::NiceSlice::engine = $engine_ok{'Filter::Util::Call'};  # default engine type
+   $PDL::NiceSlice::engine = $engine_ok{'Filter::Util::Call'};  # default engine type
 
    if ( exists $ENV{PDL_NICESLICE_ENGINE} ) {
       my $engine = $ENV{PDL_NICESLICE_ENGINE};


### PR DESCRIPTION
This is the original source filter implementation.  The more
correct one using Filter::Simple is too slow.  Work to fix is
underway but postponed for PDL-2.009