### PR TITLE
t/ops.t fail on 64-bit Strawberry Perl

### DIFF
--- a/t/ops.t
+++ b/t/ops.t
@@ -161,11 +161,15 @@ ok all(ushort($a) % ushort($b)==ushort($c)), 'ushort modulus';
 #basically this is exercising the (typecast)(X)/(N) in the macros
 $INT_MAX=2147483647;
 
+TODO: {
+local $TODO = undef;
+$TODO = 'These tests have failed since <=2.007' if $^O eq 'MSWin32';
 ok long($INT_MAX)%1 == 0, 'big long modulus';
 cmp_ok indx($INT_MAX*4)%2, '==', 0, 'big indx modulus';
 ok longlong($INT_MAX*4)%2 == 0, 'big longlong modulus';
 #skip float intentionally here, since float($INT_MAX)!=$INT_MAX
 cmp_ok double($INT_MAX*4)%2, '==', 0, 'big double modulus';
+}
 
 #and do the same for byte (unsigned char) and ushort
 $BYTE_MAX = 255;

--- a/t/ops.t
+++ b/t/ops.t
@@ -162,10 +162,10 @@ ok all(ushort($a) % ushort($b)==ushort($c)), 'ushort modulus';
 $INT_MAX=2147483647;
 
 ok long($INT_MAX)%1 == 0, 'big long modulus';
-ok indx($INT_MAX*4)%2 == 0, 'big indx modulus';
+cmp_ok indx($INT_MAX*4)%2, '==', 0, 'big indx modulus';
 ok longlong($INT_MAX*4)%2 == 0, 'big longlong modulus';
 #skip float intentionally here, since float($INT_MAX)!=$INT_MAX
-ok double($INT_MAX*4)%2 == 0, 'big double modulus';
+cmp_ok double($INT_MAX*4)%2, '==', 0, 'big double modulus';
 
 #and do the same for byte (unsigned char) and ushort
 $BYTE_MAX = 255;


### PR DESCRIPTION
This snippet:

```
$INT_MAX=2147483647;
cmp_ok indx($INT_MAX*4)%2, '==', 0, 'big indx modulus';
cmp_ok double($INT_MAX*4)%2, '==', 0, 'big double modulus';
```

It passes on my 64-bit Linux Perl 5.20.1, but on my 64-bit Strawberry Perl 5.20.0 gives these results:

```
#   Failed test 'big indx modulus'
#   at t/ops.t line 165.
#          got: 8589934592
#     expected: 0
 
#   Failed test 'big double modulus'
#   at t/ops.t line 168.
#          got: 12884901884
#     expected: 0
```