### PR TITLE
Travis-CI: add build that uses Clang as CC compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,15 @@ matrix:
       env: PDL_WITH_BADVAL=1 PDL_BADVAL_USENAN=1 PDL_BADVAL_PER_PDL=1
     - perl: "5.20"
       env: DISABLE_FORTRAN=1 # what if we don't have Fortran installed?
+    - perl: "5.20"
+      env: CC="clang" # use `clang` instead of `gcc` default
   allow_failures:
     - perl: blead
 before_install:
   - sudo apt-get update
   - sudo apt-get install build-essential libx11-dev pgplot5 libplplot-dev libgd2-xpm-dev libhdf4-alt-dev libproj-dev libvpx-dev libxpm-dev proj-bin libcfitsio3-dev libreadline-dev
   - if [ "$DISABLE_FORTRAN" != 1 ]; then sudo apt-get install gfortran; fi # set DISABLE_FOTRAN = 1 to not install gfortran
+  - if [ "$CC" == "clang" ]; then export PERL_MM_OPT='"CC=clang"'; fi # clang is already installed in Travis-CI environment. Just add to EU::MM option CC
   - sudo apt-get install libxi-dev libxmu-dev freeglut3-dev libgsl0-dev libnetpbm10-dev # for OpenGL
   - export PGPLOT_DEV=/NULL
   - perl -pi -e 's|WITH_BADVAL => 1|WITH_BADVAL => 0|       if defined $ENV{PDL_WITH_BADVAL}    && $ENV{PDL_WITH_BADVAL}     == 0' perldl.conf # disable bad value support

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install build-essential libx11-dev pgplot5 libplplot-dev libgd2-xpm-dev libhdf4-alt-dev libproj-dev libvpx-dev libxpm-dev proj-bin libcfitsio3-dev libreadline-dev
   - if [ "$DISABLE_FORTRAN" != 1 ]; then sudo apt-get install gfortran; fi # set DISABLE_FOTRAN = 1 to not install gfortran
-  - if [ "$CC" == "clang" ]; then export PERL_MM_OPT='"CC=clang"'; fi # clang is already installed in Travis-CI environment. Just add to EU::MM option CC
+  # clang is already installed in Travis-CI environment. Using PERL_MM_OPT does not work with subdirectory Makefile.PLs so we override Config.pm
+  - if [ "$CC" == "clang" ]; then mkdir build_aux; echo 'package force_clang; use ExtUtils::MakeMaker::Config; $Config{cc} = "clang"; 1' > build_aux/force_clang.pm; export PERL5OPT="-I$(pwd)/build_aux -Mforce_clang"; fi
   - sudo apt-get install libxi-dev libxmu-dev freeglut3-dev libgsl0-dev libnetpbm10-dev # for OpenGL
   - export PGPLOT_DEV=/NULL
   - perl -pi -e 's|WITH_BADVAL => 1|WITH_BADVAL => 0|       if defined $ENV{PDL_WITH_BADVAL}    && $ENV{PDL_WITH_BADVAL}     == 0' perldl.conf # disable bad value support
@@ -47,7 +48,7 @@ before_install:
   - source ~/travis-perl-helpers/init
   - build-perl
   - perl -V
-  - cpanm --quiet --notest ExtUtils::F77 Term::ReadLine::Gnu PGPLOT # do not need tests
+  - cpanm --verbose --notest ExtUtils::F77 Term::ReadLine::Gnu PGPLOT # do not need tests
   - cpanm --quiet --notest Devel::CheckLib # specify this now because this is a CONFIGURE_REQUIRES for author-side
   - cpanm --force --verbose ExtUtils::ParseXS # we install the latest ExtUtils::ParseXS
   - if [ "$EUMM_BLEAD" == 1 ]; then cpanm --quiet --notest --dev ExtUtils::MakeMaker; fi


### PR DESCRIPTION
This is in order to test against compilers other than GCC.

This fixes <https://github.com/PDLPorters/pdl/issues/13>.