### PR TITLE
Travis fix clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ before_install:
   - sudo apt-get install build-essential libx11-dev pgplot5 libplplot-dev libgd2-xpm-dev libhdf4-alt-dev libproj-dev libvpx-dev libxpm-dev proj-bin libcfitsio3-dev libreadline-dev
   - if [ "$DISABLE_FORTRAN" != 1 ]; then sudo apt-get install gfortran; fi # set DISABLE_FOTRAN = 1 to not install gfortran
   # clang is already installed in Travis-CI environment. Using PERL_MM_OPT does not work with subdirectory Makefile.PLs so we override Config.pm
-  - if [ "$CC" == "clang" ]; then mkdir build_aux; echo 'package force_clang; use ExtUtils::MakeMaker::Config; $Config{cc} = "clang"; 1' > build_aux/force_clang.pm; export PERL5OPT="-I$(pwd)/build_aux -Mforce_clang"; fi
+  # Also, both $Config{cc} and $Config{ld} need to be set because under ELF environments (such as Travis-CI's Ubuntu), this is what Perl's Config.pm does.
+  - if [ "$CC" == "clang" ]; then mkdir build_aux; echo 'package force_clang; use ExtUtils::MakeMaker::Config; $Config{cc} = $Config{ld} = "clang"; 1' > build_aux/force_clang.pm; export PERL5OPT="-I$(pwd)/build_aux -Mforce_clang"; fi
   - sudo apt-get install libxi-dev libxmu-dev freeglut3-dev libgsl0-dev libnetpbm10-dev # for OpenGL
   - export PGPLOT_DEV=/NULL
   - perl -pi -e 's|WITH_BADVAL => 1|WITH_BADVAL => 0|       if defined $ENV{PDL_WITH_BADVAL}    && $ENV{PDL_WITH_BADVAL}     == 0' perldl.conf # disable bad value support

--- a/Basic/Ufunc/Makefile.PL
+++ b/Basic/Ufunc/Makefile.PL
@@ -35,8 +35,7 @@ my %hash = pdlpp_stdargs_int(@pack);
 $hash{LIBS}->[0] .= ' -lm';
 
 #suppress warning from "$GENERIC(b) foo = 0.25;", which is intentional.
-# only do this for clang; gcc 4.8.2 on Win64 crashes
-$hash{CCFLAGS} .= ' -Wno-literal-conversion ' if $Config{cc} =~ /\bclang\b/;
+$hash{INC} .= ' -Wno-literal-conversion ';
 
 undef &MY::postamble; # suppress warning
 *MY::postamble = sub {


### PR DESCRIPTION
Fixes for building under Clang along with Travis-CI build tweaks that ensure only `clang` is used.