### PR TITLE
Fix build problem for 2.008 RC3

### DIFF
--- a/Basic/Ufunc/Makefile.PL
+++ b/Basic/Ufunc/Makefile.PL
@@ -35,7 +35,7 @@ my %hash = pdlpp_stdargs_int(@pack);
 $hash{LIBS}->[0] .= ' -lm';
 
 #suppress warning from "$GENERIC(b) foo = 0.25;", which is intentional.
-$hash{INC} .= ' -Wno-literal-conversion ';
+$hash{INC} .= ' -Wno-literal-conversion ' if $Config{cc} =~ /\bclang\b/;
 
 undef &MY::postamble; # suppress warning
 *MY::postamble = sub {


### PR DESCRIPTION
This fixes the first build problem shown in https://sourceforge.net/p/pdl/mailman/message/34029558/

The second one is from a broken Perl installation, which doesn't have `File::Path` and ignores the prereq stated in `Makefile.PL`.  Really nothing we can or should try to do about that.