### PR TITLE
Add PDL::Doc::add_module to pdlpp_postamble

### DIFF
--- a/Basic/Core/Dev.pm
+++ b/Basic/Core/Dev.pm
@@ -433,6 +433,10 @@ $pref.xs: $pref.pm
 $pref.c: $pref.xs
 
 $pref\$(OBJ_EXT): $pref.c
+
+install ::
+	\@echo "Updating PDL documentation database...";
+	\$(ABSPERLRUN) -e 'exit if \$\$ENV{DESTDIR}; use PDL::Doc; eval { PDL::Doc::add_module(q{$mod}); }; ';
 |
 	} (@_)
 }


### PR DESCRIPTION
This means eg PDL::IO::GD as an independent module will get pdldoc-ed just like modules in the monolith distro.