### PR TITLE
Fix to solaris build problem re quiet_nan

### DIFF
--- a/Basic/Math/mconf.h
+++ b/Basic/Math/mconf.h
@@ -86,6 +86,7 @@ Copyright 1984, 1987, 1989, 1995 by Stephen L. Moshier
 #include <ieeefp.h>
 #include <float.h>
 #define NANARG 1L
+#define NANARG_SIGNATURE long n
 #endif
 #if defined __alpha && ! defined __linux
 #include <float.h>
@@ -93,6 +94,7 @@ Copyright 1984, 1987, 1989, 1995 by Stephen L. Moshier
 #endif
 #ifndef NANARG
 #define NANARG
+#define NANARG_SIGNATURE
 #endif
 
 /* Redefine nan so PDL doesn't die when we see one.
@@ -154,7 +156,7 @@ int mtherr();
 extern int merror;
 
 #ifdef MY_QUIET_NAN
-extern double quiet_nan();
+extern double quiet_nan(NANARG_SIGNATURE);
 #endif
 #ifdef MY_INFINITY
 extern double infinity();

--- a/Basic/Math/quiet_nan.c
+++ b/Basic/Math/quiet_nan.c
@@ -1,6 +1,6 @@
 #include "mconf.h"
 /* Patch NaN function where no system NaN is available */
-double quiet_nan(void)
+double quiet_nan(NANARG_SIGNATURE)
 {
 #ifdef NaN
   double a;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -576,9 +576,11 @@ pdldoc.pod : pdldoc
 
 EOPS
 
+# Here, `pdl.c` is used directly because some makes (e.g., on Solaris) do not
+# support the `$<` variable in explicit rules
 $text .= <<EOT if $^O !~ /MSWin/;
 pdl$Config::Config{exe_ext} : pdl.c
-	\$(CC) \$< -o \$\@
+	\$(CC) pdl.c -o \$\@
 EOT
 
 $text .= << 'EOT' if $^O =~ /MSWin/;


### PR DESCRIPTION
It appears that the logic is already in the code,
just that the NANARG determined in mconf.h was not
used to declare the local quiet_nan version.

Works for me, seems simple.  Ok with you?