### PR TITLE
Fix sf#396, Module docs can not be found more than once.

### DIFF
--- a/Doc/Doc/Perldl.pm
+++ b/Doc/Doc/Perldl.pm
@@ -265,7 +265,8 @@ sub finddoc  {
 	   # We've got a file name and we have to open it.  With the relocatable db, we have to reconstitute the absolute pathname.
 	   my $relfile = $m->[1]{File};
 	   my $absfile = undef;
-	   for my $dbf(@{$PDL::onlinedoc->{Scanned}}) {
+	   my @scnd = @{$PDL::onlinedoc->{Scanned}};
+	   for my $dbf(@scnd){
 	       $dbf =~ s:\/[^\/]*$::; # Trim file name off the end of the database file to get just the directory
 	       $dbf .= "/$relfile";
 	       $absfile = $dbf if( -e $dbf );


### PR DESCRIPTION
If a user did 'help PDL::IO::Storable' or some other 2-deep module name,
the search for the proper module file from which to display docs
would change the reported location of the docs database (and the documentation head)
in a initialized once-per-pdl-shell variable.  Subsequent searches would
be looking for PDL/IO/IO/Storable.pm, PDL/IO/IO/IO/Storable.pm, etc,
which couldn't be found.  This was due to how foreach aliases the
loop variable to the input array.  Making an explicit copy removes
the aliasing and keeps the variable unchanged.