### PR TITLE
add a warning if the optional PGPLOT dependency is not available

### DIFF
--- a/Graphics/PGPLOT/PGPLOT.pm
+++ b/Graphics/PGPLOT/PGPLOT.pm
@@ -146,7 +146,10 @@ package PDL::Graphics::PGPLOT;
 use PDL::Core qw/:Func :Internal/; # Grab the Core names
 use PDL::Graphics::PGPLOTOptions qw(default_options);
 use PDL::Graphics::PGPLOT::Window;
-use PGPLOT;
+BEGIN {
+  eval { require PGPLOT; PGPLOT->import; 1 }
+    or die "Dependency on PGPLOT is not satisfied: $@";
+}
 use Exporter;
 
 use strict;

--- a/Graphics/PGPLOT/Window/Window.pm
+++ b/Graphics/PGPLOT/Window/Window.pm
@@ -2259,7 +2259,10 @@ use PDL::Graphics::PGPLOTOptions qw(default_options);
 use PDL::Slices;
 use PDL::NiceSlice;
 use SelfLoader;
-use PGPLOT;
+BEGIN {
+  eval { require PGPLOT; PGPLOT->import; 1 }
+    or die "Dependency on PGPLOT is not satisfied: $@";
+}
 
 require DynaLoader;
 


### PR DESCRIPTION
This warns if PGPLOT is missing when is not installed because optional
dependencies can be skipped at installation. This gives users a clear
notification of why their code will not load.

Mithaldu++ for bringing up the issue on the #pdl IRC
http://irclog.perlgeek.de/pdl/2015-09-15#i_11219756.

CC: @wchristian 

Branch note: This branch is a WIP. It still needs tests and Travis-CI support. Anyone else is welcome to move it forward.
