### PR TITLE
Mark CI testing using CI_TESTING environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ matrix:
   allow_failures:
     - perl: blead
 before_install:
+  - export CI_TESTING=1 # running under CI
   - mkdir -p ~/bin; export PATH="$HOME/bin:$PATH"; G="$HOME/bin/gfortran"; if [ "$DISABLE_FORTRAN" == 1 ]; then touch "$G"; chmod a+x "$G"; echo 'false' >"$G"; else rm -f "$G"; fi # set DISABLE_FORTRAN = 1 to not have working gfortran
   # clang is already installed in Travis-CI environment. Using PERL_MM_OPT does not work with subdirectory Makefile.PLs so we override Config.pm
   # Also, both $Config{cc} and $Config{ld} need to be set because under ELF environments (such as Travis-CI's Ubuntu), this is what Perl's Config.pm does.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 version: 1.0.{build}
 
 install:
+  # running under CI
+  - set CI_TESTING=1
   - cinst StrawberryPerl
   - path C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
   - mkdir %APPVEYOR_BUILD_FOLDER%\tmp

--- a/t/bigmem.t
+++ b/t/bigmem.t
@@ -9,7 +9,7 @@
 use Test::More;
 
 BEGIN {
-   if ($ENV{AUTOMATED_TESTING} or $ENV{TRAVIS_BUILD_ID}) {
+   if ($ENV{AUTOMATED_TESTING} or $ENV{CI_TESTING}) {
       plan skip_all => 'bigmem tests skipped to avoid OOM fails';
    } else {
       plan tests => 1;


### PR DESCRIPTION
This is used to skip `t/bigmem.t` so that it does not die due to an OOM condition.