### PR TITLE
fix for SF#398 "$pdl->hdr items are lost after $pdl->reshape"

### DIFF
--- a/Basic/Core/Core.pm
+++ b/Basic/Core/Core.pm
@@ -2631,7 +2631,7 @@ sub PDL::reshape{
     if (@_ == 2 && $_[1] == -1) {  # a slicing reshape that drops 1-dims
 	return $_[0]->slice( map { $_==1 ? [0,0,0] : [] } $_[0]->dims);
     }
-    my $pdl = pdl($_[0]);
+    my $pdl = topdl($_[0]);
     my $nelem = $pdl->nelem;
     my @dims = grep defined, @_[1..$#_];
     for my $dim(@dims) { barf "reshape: invalid dim size '$dim'" if $dim < 0 }

--- a/t/core.t
+++ b/t/core.t
@@ -13,7 +13,7 @@ BEGIN {
     eval {
         require PDL::LiteF;
     } or BAIL_OUT("PDL::LiteF failed: $@");
-    plan tests => 58;
+    plan tests => 60;
     PDL::LiteF->import;
 }
 $| = 1;
@@ -82,6 +82,12 @@ ok $d->reshape(-1)->ndims==0, "reshape(-1) on 0-dim PDL gives 0-dim PDL";
 ok $d->reshape(1)->ndims==1, "reshape(1) on 0-dim PDL gives 1-dim PDL";
 ok $d->reshape(1)->reshape(-1)->ndims==0, "reshape(-1) on 1-dim, 1-element PDL gives 0-dim PDL";
 
+# reshape test related to bug SF#398 "$pdl->hdr items are lost after $pdl->reshape"
+$c = ones(25);
+$c->hdr->{demo} = "yes";
+is($c->hdr->{demo}, "yes", "hdr before reshape");
+$c->reshape(5,5);
+is($c->hdr->{demo}, "yes", "hdr after reshape");
 
 
 


### PR DESCRIPTION
Verify kmx fix for sf bug #398