### PR TITLE
New commit also fixes Bug #400 (bigpdl slice-of-slice problem)

### DIFF
--- a/Basic/Core/Makefile.PL
+++ b/Basic/Core/Makefile.PL
@@ -10,7 +10,6 @@ my $pthread_include = $Config::Config{usrinc};  # not good for win32
 my $pthread_library = '-lpthread';                                  # not good for MSVC
 my $pthread_define  = ' -DPDL_PTHREAD ';
 
-my $macos_braindamage_define = ($^O eq 'darwin') ? " -DMACOS_MZERO_BRAINDAMAGE " : "";
 my $badval_define = " -DBADVAL=$PDL::Config{WITH_BADVAL} -DBADVAL_USENAN=$PDL::Config{BADVAL_USENAN} -DBADVAL_PER_PDL=$PDL::Config{BADVAL_PER_PDL}";
 
 my $malloclib = $PDL::Config{MALLOCDBG}->{libs};
@@ -239,7 +238,7 @@ WriteMakefile(
 		},
  'PL_FILES'     => {map {($_ => nopl $_)} grep {!/^Makefile.PL$/} <*.PL>},
  'OBJECT'       => 'Core$(OBJ_EXT) ' . $cobj,
- 'DEFINE' 	=> $pthread_define.$macos_braindamage_define.$badval_define,
+ 'DEFINE' 	=> $pthread_define.$badval_define,
  'LIBS'         => ["$pthread_library $malloclib"],
  'clean'        => {'FILES'  => $cobj .
                    ' pdlconv.c pdlsections.c pdlcore.c '.

--- a/Basic/Core/pdlapi.c
+++ b/Basic/Core/pdlapi.c
@@ -1497,7 +1497,7 @@ void pdl_make_physvaffine(pdl *it)
 			it->vafftrans->incs[i] = incsleft[i];
 		}
 		{
-			int offset_left = it->vafftrans->offs;
+			PDL_Indx offset_left = it->vafftrans->offs;
 			inc = it->vafftrans->offs;
 			newinc = 0;
 			for(j=current->ndims-1; j>=0 && current->dimincs[j] != 0; j--) {

--- a/Basic/Core/pdlsections.g
+++ b/Basic/Core/pdlsections.g
@@ -230,11 +230,6 @@ PDL_Anyval pdl_at( void* x, int datatype, PDL_Indx* pos, PDL_Indx* dims,
 
    ENDGENERICLOOP
 
-#ifdef MACOS_MZERO_BRAINDAMAGE
-    if(!result)
-        result=0;
-#endif
-
    return result;
 }
 

--- a/t/bigmem.t
+++ b/t/bigmem.t
@@ -12,7 +12,7 @@ BEGIN {
    if ($ENV{AUTOMATED_TESTING} or $ENV{CI_TESTING}) {
       plan skip_all => 'bigmem tests skipped to avoid OOM fails';
    } else {
-      plan tests => 1;
+      plan tests => 2;
    }
 }
 
@@ -34,6 +34,11 @@ $PDL::BIGPDL = 1;  # should this be the defaults for 64bit index support?
 
 my $bigbyte = ones( byte, 5*1024*1024*1024+17 );
 ok( $bigbyte->shape->sclr == $bigbyte->nelem, "shape handles indx dims > 4GiB");
+
+$bigbyte = ones(byte, 2**30, 4);
+my $aaa = $bigbyte->slice("3:-10");
+my $bbb = $aaa->slice(":,3");
+ok( $bbb->sum == $bbb->nelem, "slices of slices of giant PDLs seem to work right");
 
 # ndims
 # getndims


### PR DESCRIPTION
Bug was due to an "int" temporary variable in the vafftrans calculation code, which should have been PDL_Indx (and is now).