### PR TITLE
make pdl_whichdatatype_double work for NVSIZE > 8

### DIFF
--- a/Basic/Core/pdlcore.c.PL
+++ b/Basic/Core/pdlcore.c.PL
@@ -302,8 +302,12 @@ int pdl_whichdatatype_double (NV nv) {
         TESTTYPE(PDL_D,PDL_Double)
 
         if( !finite(nv) ) { return PDL_D; }
-        croak("Something's gone wrong: %lf cannot be converted by whichdatatype_double",
-                nv);
+#if NVSIZE > 8
+        warn("Precision loss due to 'long double' to 'PDL_D' conversion!");
+        return PDL_D;
+#else
+        croak("Something's gone wrong: %lf cannot be converted by whichdatatype_double",  nv);
+#endif 
 }
 
 


### PR DESCRIPTION
A warning is now given if there is a loss of precision to avoid user surprise.  kmx has pointed out this could be annoying and we may need to make the warning quiet after the first time.  Lets see what shows in the tests on long double systems to see how bad it is.