### PR TITLE
sf376 storable segfault

### DIFF
--- a/Basic/PDL.pm
+++ b/Basic/PDL.pm
@@ -140,6 +140,7 @@ start-up modules.
    use PDL::IO::Misc;
    use PDL::IO::FITS;
    use PDL::IO::Pic;
+   use PDL::IO::Storable;
    use PDL::Lvalue;
 
 =cut
@@ -179,6 +180,10 @@ use PDL::IO::Pic;           # rpic/wpic
 # Load this so config/install info is available
 
 use PDL::Config;
+
+# Load this to avoid mysterious Storable segfaults
+
+use PDL::IO::Storable;
 
 EOD
 

--- a/IO/Storable/storable.pd
+++ b/IO/Storable/storable.pd
@@ -192,7 +192,6 @@ sub pdlunpack {
                     $PDL::Types::PDL_S,
                     $PDL::Types::PDL_U,
                     $PDL::Types::PDL_L,
-                    $PDL::Types::PDL_N,
                     $PDL::Types::PDL_LL,
                     $PDL::Types::PDL_F,
                     $PDL::Types::PDL_D);

--- a/IO/Storable/storable.pd
+++ b/IO/Storable/storable.pd
@@ -192,6 +192,7 @@ sub pdlunpack {
                     $PDL::Types::PDL_S,
                     $PDL::Types::PDL_U,
                     $PDL::Types::PDL_L,
+                    $PDL::Types::PDL_N,
                     $PDL::Types::PDL_LL,
                     $PDL::Types::PDL_F,
                     $PDL::Types::PDL_D);


### PR DESCRIPTION
Fix SEGFAULT with Storable by adding PDL::IO::Storable to PDL.pm so incorrect usage won't cause a mysterious crash as shown in http://sourceforge.net/p/pdl/bugs/376/ .  This seems a reasonable solution since PDL::IO::Storable is self-contained and needed for Storable to work correctly with PDL.