### PR TITLE
Move NVSIZE>8 warning to Core.xs BOOT

### DIFF
--- a/Basic/Core/Core.xs
+++ b/Basic/Core/Core.xs
@@ -881,6 +881,10 @@ set_c(x,position,value)
        pdl_changed( x , PDL_PARENTDATACHANGED , 0 );
 
 BOOT:
+{
+#if NVSIZE > 8
+   fprintf(stderr, "Your perl NV has more precision than PDL_Double.  There will be loss of floating point precision!\n");
+#endif
 
    /* Initialize structure of pointers to core C routines */
 
@@ -951,6 +955,7 @@ BOOT:
        by other modules
    */
    sv_setiv(get_sv("PDL::SHARE",TRUE|GV_ADDMULTI), PTR2IV(&PDL));
+}
 
 # make piddle belonging to 'class' and of type 'type'
 # from avref 'array_ref' which is checked for being

--- a/Basic/Core/pdlcore.c.PL
+++ b/Basic/Core/pdlcore.c.PL
@@ -301,13 +301,8 @@ int pdl_whichdatatype_double (NV nv) {
         TESTTYPE(PDL_F,PDL_Float)
         TESTTYPE(PDL_D,PDL_Double)
 
-        if( !finite(nv) ) { return PDL_D; }
-#if NVSIZE > 8
-        warn("Precision loss due to 'long double' to 'PDL_D' conversion!");
+        /* Default return type PDL_Double */
         return PDL_D;
-#else
-        croak("Something's gone wrong: %lf cannot be converted by whichdatatype_double",  nv);
-#endif 
 }
 
 


### PR DESCRIPTION
This gives a one time warning that precision will be lost
converting from perl NV to PDL_Doubles.  Removed careful
but useless logic and croak from pdl_whichdatatype_double().