### PR TITLE
Add $PDL::indxformat for PDL_Indx

### DIFF
--- a/Basic/Core/Core.pm
+++ b/Basic/Core/Core.pm
@@ -1092,7 +1092,7 @@ sub PDL::Core::new_pdl_from_string {
    $nan->upd_data();
    $value =~ s/\beE\b/pi/g;
 
-   my $val = eval{
+   my $val = eval {
       # Install the warnings handler:
       my $old_warn_handler = $SIG{__WARN__};
       local $SIG{__WARN__} = sub {
@@ -1209,7 +1209,9 @@ sub PDL::Core::parse_basic_string {
 		elsif (s/^([\d+\-e.]+)//i) {
 			# Note that improper numbers are handled by the warning signal
 			# handler
-			push @to_return, $sign * $1;
+                        my $val = $1;
+                        my $nval = $val + 0x0;
+                        push @to_return, ($sign>0x0) ? $nval : -$nval;
 		}
 		else {
 			die "Incorrectly formatted input at:\n  ", substr ($_, 0, 10), "...\n";

--- a/Basic/Core/Core.pm
+++ b/Basic/Core/Core.pm
@@ -262,8 +262,8 @@ Whether to insert commas when printing pdls
 
 =over 4
 
-The default print format for floats and doubles, repectively.
-The default default values are:
+The default print format for floats, doubles, and indx values,
+repectively.  The default default values are:
 
   $PDL::floatformat  = "%7g";
   $PDL::doubleformat = "%10.8g";
@@ -338,22 +338,31 @@ PDL constructor - creates new piddle from perl scalars/arrays, piddles, and stri
 
 =for usage
 
- $a = pdl(SCALAR|ARRAY REFERENCE|ARRAY|STRING);
+ $double_pdl = pdl(SCALAR|ARRAY REFERENCE|ARRAY|STRING);  # default type
+ $type_pdl   = pdl(PDL::Type,SCALAR|ARRAY REFERENCE|ARRAY|STRING);
 
 =for example
 
- $a = pdl [1..10];             # 1D array
- $a = pdl ([1..10]);           # 1D array
- $a = pdl (1,2,3,4);           # Ditto
- $b = pdl [[1,2,3],[4,5,6]];   # 2D 3x2 array
- $b = pdl "[[1,2,3],[4,5,6]]"; # Ditto (slower)
- $b = pdl "[1 2 3; 4 5 6]";    # Ditto
- $b = pdl q[1 2 3; 4 5 6];     # Ditto, using the q quote operator
- $b = pdl "1 2 3; 4 5 6";      # Ditto, less obvious, but still works
- $b = pdl 42                   # 0-dimensional scalar
- $c = pdl $a;                  # Make a new copy
- $a = pdl([1,2,3],[4,5,6]);    # 2D
- $a = pdl([[1,2,3],[4,5,6]]);  # 2D
+ $a = pdl [1..10];                    # 1D array
+ $a = pdl ([1..10]);                  # 1D array
+ $a = pdl (1,2,3,4);                  # Ditto
+ $b = pdl [[1,2,3],[4,5,6]];          # 2D 3x2 array
+ $b = pdl "[[1,2,3],[4,5,6]]";        # Ditto (slower)
+ $b = pdl "[1 2 3; 4 5 6]";           # Ditto
+ $b = pdl q[1 2 3; 4 5 6];            # Ditto, using the q quote operator
+ $b = pdl "1 2 3; 4 5 6";             # Ditto, less obvious, but still works
+ $b = pdl 42                          # 0-dimensional scalar
+ $c = pdl $a;                         # Make a new copy
+
+ $u = pdl ushort(), 42                # 0-dimensional ushort scalar
+ $b = pdl(byte(),[[1,2,3],[4,5,6]]);  # 2D byte piddle
+
+ $n = pdl indx(), [1..5];             # 1D array of indx values
+ $n = pdl indx, [1..5];               # ... can leave off parens
+ $n = indx( [1..5] );                 # ... still the same!
+
+ $a = pdl([1,2,3],[4,5,6]);           # 2D
+ $a = pdl([1,2,3],[4,5,6]);           # 2D
 
 Note the last two are equivalent - a list is automatically
 converted to a list reference for syntactic convenience. i.e. you

--- a/Basic/Core/Core.pm
+++ b/Basic/Core/Core.pm
@@ -41,6 +41,7 @@ $PDL::verbose      = 0;
 $PDL::use_commas   = 0;        # Whether to insert commas when printing arrays
 $PDL::floatformat  = "%7g";    # Default print format for long numbers
 $PDL::doubleformat = "%10.8g";
+$PDL::indxformat   = "%12d";   # Default print format for PDL_Indx values
 $PDL::undefval     = 0;        # Value to use instead of undef when creating PDLs
 $PDL::toolongtoprint = 10000;  # maximum pdl size to stringify for printing
 
@@ -257,7 +258,7 @@ Whether to insert commas when printing pdls
 
 =back
 
-=head3 C<$PDL::floatformat>, C<$PDL::doubleformat>
+=head3 C<$PDL::floatformat>, C<$PDL::doubleformat>, C<$PDL::indxformat>
 
 =over 4
 
@@ -266,6 +267,7 @@ The default default values are:
 
   $PDL::floatformat  = "%7g";
   $PDL::doubleformat = "%10.8g";
+  $PDL::indxformat   = "%12d";
 
 =back
 
@@ -3448,6 +3450,7 @@ sub str1D {
     my $dtype = $self->get_datatype();
     $dformat = $PDL::floatformat  if $dtype == $PDL_F;
     $dformat = $PDL::doubleformat if $dtype == $PDL_D;
+    $dformat = $PDL::indxformat if $dtype == $PDL_IND;
 
     my $badflag = $self->badflag();
     for $t (@$x) {
@@ -3502,6 +3505,8 @@ sub str2D{
 		$format = $PDL::floatformat;
 	    } elsif ($dtype == $PDL_D) {
 		$format = $PDL::doubleformat;
+	    } elsif ($dtype == $PDL_IND) {
+		$format = $PDL::indxformat;
 	    } else {
 		# Stick with default
 		$findmax = 0;


### PR DESCRIPTION
This avoids loss of significance when 64bit PDL_Indx
values are printed.  Part of the 64bit cleanup and polish
for PDL-2.015 (planned for release by Dec 2015)