### PR TITLE
Require ccNcompt return type to be >= long.

### DIFF
--- a/Lib/Image2D/image2d.pd
+++ b/Lib/Image2D/image2d.pd
@@ -1156,7 +1156,7 @@ where the second parameter specifies the connectivity (4 or 8) of the labeling.
 
 ',
        HandleBad => 0, # a marker
-        Pars => 'a(m,n); [o]b(m,n);',
+        Pars => 'a(m,n); int+ [o]b(m,n);',
         OtherPars => 'int con',
         Code => '
 

--- a/t/image2d.t
+++ b/t/image2d.t
@@ -3,7 +3,7 @@
 
 use Test;
 BEGIN {
-    plan tests => 26;
+    plan tests => 28;
 }
 
 use PDL;
@@ -146,6 +146,10 @@ eval 'ccNcompt($a,5)';
 ok($@ ne '');
 eval 'ccNcompt($a,8)';
 ok($@ eq '');
+my $im = (xvals(25,25)+yvals(25,25));
+my $seg_b = cc4compt(byte $im%2);
+ok($seg_b->type >= long);
+ok(cc4compt($im%2)->max == $seg_b->max);
 
 # pnpoly
 my $px = pdl(0,3,1);


### PR DESCRIPTION
Add 2 tests to check for this for byte image inputs.