### PR TITLE
Include support for GSL 2.0

### DIFF
--- a/Lib/GSL/SF/ellint/gsl_sf_ellint.pd
+++ b/Lib/GSL/SF/ellint/gsl_sf_ellint.pd
@@ -5,7 +5,7 @@ PDL::GSLSF::ELLINT - PDL interface to GSL Special Functions
 
 =head1 DESCRIPTION
 
-This is an interface to the Special Function package present in the GNU Scientific Library. 
+This is an interface to the Special Function package present in the GNU Scientific Library.
 
 =head1 SYNOPSIS
 
@@ -28,7 +28,7 @@ pp_def('gsl_sf_ellint_Kcomp',
 gsl_sf_result r;
 GSLERR(gsl_sf_ellint_Kcomp_e,($k(),GSL_PREC_DOUBLE,&r))
 $y() = r.val;
-$e() = r.err; 
+$e() = r.err;
 ',
        Doc =>'Legendre form of complete elliptic integrals K(k) = Integral[1/Sqrt[1 - k^2 Sin[t]^2], {t, 0, Pi/2}].'
       );
@@ -40,7 +40,7 @@ pp_def('gsl_sf_ellint_Ecomp',
 gsl_sf_result r;
 GSLERR(gsl_sf_ellint_Ecomp_e,($k(),GSL_PREC_DOUBLE,&r))
 $y() = r.val;
-$e() = r.err; 
+$e() = r.err;
 ',
        Doc =>'Legendre form of complete elliptic integrals E(k) = Integral[  Sqrt[1 - k^2 Sin[t]^2], {t, 0, Pi/2}]'
       );
@@ -52,7 +52,7 @@ pp_def('gsl_sf_ellint_F',
 gsl_sf_result r;
 GSLERR(gsl_sf_ellint_F_e,($phi(),$k(),GSL_PREC_DOUBLE,&r))
 $y() = r.val;
-$e() = r.err; 
+$e() = r.err;
 ',
        Doc =>'Legendre form of incomplete elliptic integrals F(phi,k)   = Integral[1/Sqrt[1 - k^2 Sin[t]^2], {t, 0, phi}]'
       );
@@ -64,7 +64,7 @@ pp_def('gsl_sf_ellint_E',
 gsl_sf_result r;
 GSLERR(gsl_sf_ellint_E_e,($phi(),$k(),GSL_PREC_DOUBLE,&r))
 $y() = r.val;
-$e() = r.err; 
+$e() = r.err;
 ',
        Doc =>'Legendre form of incomplete elliptic integrals E(phi,k)   = Integral[  Sqrt[1 - k^2 Sin[t]^2], {t, 0, phi}]'
       );
@@ -77,10 +77,14 @@ pp_def('gsl_sf_ellint_P',
 gsl_sf_result r;
 GSLERR(gsl_sf_ellint_P_e,($phi(),$k(),$n(),GSL_PREC_DOUBLE,&r))
 $y() = r.val;
-$e() = r.err; 
+$e() = r.err;
 ',
        Doc =>'Legendre form of incomplete elliptic integrals P(phi,k,n) = Integral[(1 + n Sin[t]^2)^(-1)/Sqrt[1 - k^2 Sin[t]^2], {t, 0, phi}]'
       );
+
+my $v = `gsl-config --version`;
+
+if($v < 2.0) {
 
 pp_def('gsl_sf_ellint_D',
        GenericTypes => [D],
@@ -90,10 +94,28 @@ pp_def('gsl_sf_ellint_D',
 gsl_sf_result r;
 GSLERR(gsl_sf_ellint_D_e,($phi(),$k(),$n(),GSL_PREC_DOUBLE,&r))
 $y() = r.val;
-$e() = r.err; 
+$e() = r.err;
 ',
        Doc =>'Legendre form of incomplete elliptic integrals D(phi,k,n)'
       );
+
+}
+else {
+
+pp_def('gsl_sf_ellint_D',
+       GenericTypes => [D],
+       Pars=>'double phi(); double k();
+              double [o]y(); double [o]e()',
+       Code =>'
+gsl_sf_result r;
+GSLERR(gsl_sf_ellint_D_e,($phi(),$k(),GSL_PREC_DOUBLE,&r))
+$y() = r.val;
+$e() = r.err;
+',
+       Doc =>'Legendre form of incomplete elliptic integrals D(phi,k)'
+      );
+
+}
 
 pp_def('gsl_sf_ellint_RC',
        GenericTypes => [D],
@@ -102,7 +124,7 @@ pp_def('gsl_sf_ellint_RC',
 gsl_sf_result r;
 GSLERR(gsl_sf_ellint_RC_e,($x(),$yy(),GSL_PREC_DOUBLE,&r))
 $y() = r.val;
-$e() = r.err; 
+$e() = r.err;
 ',
        Doc =>'Carlsons symmetric basis of functions RC(x,y)   = 1/2 Integral[(t+x)^(-1/2) (t+y)^(-1)], {t,0,Inf}'
       );
@@ -114,7 +136,7 @@ pp_def('gsl_sf_ellint_RD',
 gsl_sf_result r;
 GSLERR(gsl_sf_ellint_RD_e,($x(),$yy(),$z(),GSL_PREC_DOUBLE,&r))
 $y() = r.val;
-$e() = r.err; 
+$e() = r.err;
 ',
        Doc =>'Carlsons symmetric basis of functions RD(x,y,z) = 3/2 Integral[(t+x)^(-1/2) (t+y)^(-1/2) (t+z)^(-3/2), {t,0,Inf}]'
       );
@@ -126,7 +148,7 @@ pp_def('gsl_sf_ellint_RF',
 gsl_sf_result r;
 GSLERR(gsl_sf_ellint_RF_e,($x(),$yy(),$z(),GSL_PREC_DOUBLE,&r))
 $y() = r.val;
-$e() = r.err; 
+$e() = r.err;
 ',
        Doc =>'Carlsons symmetric basis of functions RF(x,y,z) = 1/2 Integral[(t+x)^(-1/2) (t+y)^(-1/2) (t+z)^(-1/2), {t,0,Inf}]'
       );
@@ -138,7 +160,7 @@ pp_def('gsl_sf_ellint_RJ',
 gsl_sf_result r;
 GSLERR(gsl_sf_ellint_RJ_e,($x(),$yy(),$z(),$p(),GSL_PREC_DOUBLE,&r))
 $y() = r.val;
-$e() = r.err; 
+$e() = r.err;
 ',
        Doc =>'Carlsons symmetric basis of functions RJ(x,y,z,p) = 3/2 Integral[(t+x)^(-1/2) (t+y)^(-1/2) (t+z)^(-1/2) (t+p)^(-1), {t,0,Inf}]'
       );

--- a/Lib/GSL/SF/legendre/gsl_sf_legendre.pd
+++ b/Lib/GSL/SF/legendre/gsl_sf_legendre.pd
@@ -77,7 +77,8 @@ pp_def('gsl_sf_legendre_Plm_array',
        Code =>'
 GSLERR(gsl_sf_legendre_Plm_array,($COMP(l)-2+$COMP(m),$COMP(m),$x(),$P(y)))
 ',
-       Doc =>'P_lm(x) for l from 0 to n-2+m.'
+       Doc =>'P_lm(x) for l from 0 to n-2+m.
+gsl_sf_legendre_Plm_array has been deprecated in GSL version 2.0. It is included here for backwards compatability and may be removed in a future release.  New code should use L<gsl_sf_legendre_array> instead.'
       );
 
 pp_def('gsl_sf_legendre_sphPlm',
@@ -100,7 +101,8 @@ pp_def('gsl_sf_legendre_sphPlm_array',
        Code =>'
 GSLERR(gsl_sf_legendre_sphPlm_array,($COMP(n)-2+$COMP(m),$COMP(m),$x(),$P(y)))
 ',
-       Doc =>'P_lm(x), normalized properly for use in spherical harmonics for l from 0 to n-2+m.'
+       Doc =>'P_lm(x), normalized properly for use in spherical harmonics for l from 0 to n-2+m.
+gsl_sf_legendre_sphPlm_array has been deprecated in GSL version 2.0. It is included here for backwards compatability and may be removed in a future release.  New code should use L<gsl_sf_legendre_array> instead.'
       );
 
 pp_def('gsl_sf_conicalP_half',

--- a/Lib/GSL/SF/legendre/gsl_sf_legendre.pd
+++ b/Lib/GSL/SF/legendre/gsl_sf_legendre.pd
@@ -71,7 +71,7 @@ $e() = r.err;
       );
 
 my $v = `gsl-config --version`;
-if ($v>=2.0){
+if (defined($v) && $v>=2.0){
 
     pp_def('gsl_sf_legendre_array',
 	   GenericTypes => [D],
@@ -196,8 +196,7 @@ Note that this function is called differently than the corresponding GSL functio
 	);
 
 
-}
-
+} elsif (defined($v) && $v<2.0) {
 
 pp_def('gsl_sf_legendre_Plm_array',
        GenericTypes => [D],
@@ -210,6 +209,21 @@ GSLERR(gsl_sf_legendre_Plm_array,($COMP(l)-2+$COMP(m),$COMP(m),$x(),$P(y)))
 gsl_sf_legendre_Plm_array has been deprecated in GSL version 2.0. It is included here for backwards compatability and may be removed in a future release.  New code should use L<gsl_sf_legendre_array> instead.'
       );
 
+pp_def('gsl_sf_legendre_sphPlm_array',
+       GenericTypes => [D],
+       OtherPars =>'int n=>num; int m',
+       Pars=>'double x(); double [o]y(num)',
+       Code =>'
+GSLERR(gsl_sf_legendre_sphPlm_array,($COMP(n)-2+$COMP(m),$COMP(m),$x(),$P(y)))
+',
+       Doc =>'P_lm(x), normalized properly for use in spherical harmonics for l from 0 to n-2+m.
+gsl_sf_legendre_sphPlm_array has been deprecated in GSL version 2.0. It is included here for backwards compatability and may be removed in a future release.  New code should use L<gsl_sf_legendre_array> instead.'
+      );
+
+} else {
+die("Could not determine GSL version from gsl-config, so can not determine which legendre array functions to define.");
+}
+
 pp_def('gsl_sf_legendre_sphPlm',
        GenericTypes => [D],
        OtherPars =>'int l; int m',
@@ -221,17 +235,6 @@ $y() = r.val;
 $e() = r.err; 
 ',
        Doc =>'P_lm(x), normalized properly for use in spherical harmonics'
-      );
-
-pp_def('gsl_sf_legendre_sphPlm_array',
-       GenericTypes => [D],
-       OtherPars =>'int n=>num; int m',
-       Pars=>'double x(); double [o]y(num)',
-       Code =>'
-GSLERR(gsl_sf_legendre_sphPlm_array,($COMP(n)-2+$COMP(m),$COMP(m),$x(),$P(y)))
-',
-       Doc =>'P_lm(x), normalized properly for use in spherical harmonics for l from 0 to n-2+m.
-gsl_sf_legendre_sphPlm_array has been deprecated in GSL version 2.0. It is included here for backwards compatability and may be removed in a future release.  New code should use L<gsl_sf_legendre_array> instead.'
       );
 
 pp_def('gsl_sf_conicalP_half',

--- a/Lib/GSL/SF/legendre/gsl_sf_legendre.pd
+++ b/Lib/GSL/SF/legendre/gsl_sf_legendre.pd
@@ -70,6 +70,135 @@ $e() = r.err;
        Doc =>'P_lm(x)'
       );
 
+my $v = `gsl-config --version`;
+if ($v>=2.0){
+
+    pp_def('gsl_sf_legendre_array',
+	   GenericTypes => [D],
+	   OtherPars => 'char norm;  int lmax; int csphase',
+	   Pars => 'double x(); double [o]y(n); double [t]work(wn)',
+	   RedoDimsCode => '
+$SIZE(wn)=gsl_sf_legendre_array_n($COMP(lmax));
+$SIZE(n)=$COMP(lmax)*($COMP(lmax)+1)/2+$COMP(lmax)+1;
+',
+	   Code => <<'EOC',
+           int i;
+           if($x()<-1||$x()>1) barf("The input to gsl_sf_legendre_array must be abs(x)<=1, and you input %f. Try normalizing your input.",$x());
+	   switch ($COMP(norm)){
+	       case 'P' :
+		   GSLERR(gsl_sf_legendre_array_e,(GSL_SF_LEGENDRE_NONE, $COMP(lmax), $x(), $COMP(csphase), $P(work)));
+	       break;
+	       case 'S' :
+		   GSLERR(gsl_sf_legendre_array_e,(GSL_SF_LEGENDRE_SCHMIDT, $COMP(lmax), $x(), $COMP(csphase), $P(work)));
+	       break;
+	       case 'Y' :
+		   GSLERR(gsl_sf_legendre_array_e,(GSL_SF_LEGENDRE_SPHARM, $COMP(lmax), $x(), $COMP(csphase), $P(work)));
+	       break;
+	       case 'N' :
+		   GSLERR(gsl_sf_legendre_array_e,(GSL_SF_LEGENDRE_FULL, $COMP(lmax), $x(), $COMP(csphase), $P(work)));
+	       break;
+               default :
+                ;
+           }
+           for(i=0; i<$SIZE(n); i++) {
+              $y(n=>i) = $work(wn=>i);
+           }
+
+EOC
+
+	   HandleBad => 1,
+	   BadCode => <<'EOBC',
+	   int i;
+	   if ( $ISBAD( x() ) ) {
+              loop(n) %{ $SETBAD ( y() ); %}
+	   } else {
+             if($x()<-1||$x()>1) barf("The input to gsl_sf_legendre_array must be abs(x)<=1, and you input %f",$x());
+	     switch ($COMP(norm)) {
+		   case 'P' :
+		       GSLERR(gsl_sf_legendre_array_e,(GSL_SF_LEGENDRE_NONE, $COMP(lmax), $x(), $COMP(csphase), $P(work)));
+		   break;
+		   case 'S' :
+		       GSLERR(gsl_sf_legendre_array_e,(GSL_SF_LEGENDRE_SCHMIDT, $COMP(lmax), $x(), $COMP(csphase), $P(work)));
+		   break;
+		   case 'Y' :
+		       GSLERR(gsl_sf_legendre_array_e,(GSL_SF_LEGENDRE_SPHARM, $COMP(lmax), $x(), $COMP(csphase), $P(work)));
+		   break;
+		   case 'N' :
+		       GSLERR(gsl_sf_legendre_array_e,(GSL_SF_LEGENDRE_FULL, $COMP(lmax), $x(), $COMP(csphase), $P(work)));
+		   break;
+		   default :
+		       ;
+	       }
+             for(i=0; i<$SIZE(n); i++) {
+                $y(n=>i) = $work(wn=>i);
+             }
+	   }
+
+EOBC
+
+
+
+	   Doc => <<'EOD',
+=for ref
+
+Calculate all normalized associated Legendre polynomials.
+
+=for usage
+
+$Plm = gsl_sf_legendre_array($x,'P',4,-1);
+
+The calculation is done for degree 0 <= l <= lmax and order 0 <= m <= l on the range abs(x)<=1.
+
+The parameter norm should be:
+
+=over 3
+
+=item 'P' for unnormalized associated Legendre polynomials P_l^m(x),
+
+=item 'S' for Schmidt semi-normalized associated Legendre polynomials S_l^m(x),
+
+=item 'Y' for spherical harmonic associated Legendre polynomials Y_l^m(x), or
+
+=item 'N' for fully normalized associated Legendre polynomials N_l^m(x).
+
+=back
+
+lmax is the maximum degree l.
+csphase should be (-1) to INCLUDE the Condon-Shortley phase factor (-1)^m, or (+1) to EXCLUDE it.
+
+See L<gsl_sf_legendre_array_index> to get the value of C<l> and C<m> in the returned vector.
+
+EOD
+
+	);
+
+    pp_def('gsl_sf_legendre_array_index',
+	   OtherPars => 'int lmax',
+	   Pars => 'int [o]l(n); int [o]m(n)',
+	   RedoDimsCode => '$SIZE(n)=$COMP(lmax)*($COMP(lmax)+1)/2+$COMP(lmax)+1;',
+	   Code => q/
+           int ell, em, index;
+	   for (ell=0; ell<=$COMP(lmax); ell++){
+	       for (em=0; em<=ell; em++){
+		   index = gsl_sf_legendre_array_index(ell,em);
+		   $l(n=>index)=ell;
+		   $m(n=>index)=em;
+	       }
+	   }/,
+	   Doc =>'=for ref
+
+Calculate the relation between gsl_sf_legendre_arrays index and l and m values.
+
+=for usage
+($l,$m) = gsl_sf_legendre_array_index($lmax);
+
+Note that this function is called differently than the corresponding GSL function, to make it more useful for PDL: here you just input the maximum l (lmax) that was used in C<gsl_sf_legendre_array> and it calculates all l and m values.'
+	);
+
+
+}
+
+
 pp_def('gsl_sf_legendre_Plm_array',
        GenericTypes => [D],
        OtherPars =>'int l=>num; int m',

--- a/t/gsl_sf.t
+++ b/t/gsl_sf.t
@@ -3,33 +3,68 @@
 # Test Script for the PDL interface to the GSL library
 #  This tests only that the interface is working, i.e. that the
 #   functions can be called. The actual return values are not
-#   checked. 
+#   checked.
 #  The GSL library already has a extensive test suite, and we
 #  do not want to duplicate that effort here.
 
 use PDL::LiteF;
 use Test::More;
+use strict;
 
 BEGIN
 {
    use PDL::Config;
    if ( $PDL::Config{WITH_GSL} ) {
-      eval " use PDL::GSLSF::BESSEL; ";
+      eval {
+	  use PDL::GSLSF::AIRY;
+	  use PDL::GSLSF::BESSEL;
+	  use PDL::GSLSF::CLAUSEN;
+	  use PDL::GSLSF::COULOMB;
+	  use PDL::GSLSF::COUPLING;
+	  use PDL::GSLSF::DAWSON;
+	  use PDL::GSLSF::DEBYE;
+	  use PDL::GSLSF::DILOG;
+	  use PDL::GSLSF::ELEMENTARY;
+	  use PDL::GSLSF::ELLINT;
+	  use PDL::GSLSF::ELLJAC;
+	  use PDL::GSLSF::ERF;
+	  use PDL::GSLSF::EXP;
+	  use PDL::GSLSF::EXPINT;
+	  use PDL::GSLSF::FERMI_DIRAC;
+	  use PDL::GSLSF::GAMMA;
+	  use PDL::GSLSF::GEGENBAUER;
+	  use PDL::GSLSF::HYPERG;
+	  use PDL::GSLSF::LAGUERRE;
+	  use PDL::GSLSF::LEGENDRE;
+	  use PDL::GSLSF::LOG;
+	  use PDL::GSLSF::POLY;
+	  use PDL::GSLSF::POW_INT;
+	  use PDL::GSLSF::PSI;
+	  use PDL::GSLSF::SYNCHROTRON;
+	  use PDL::GSLSF::TRANSPORT;
+	  use PDL::GSLSF::TRIG;
+	  use PDL::GSLSF::ZETA;
+      };
       unless ($@) {
-         plan tests => 1;
+         plan tests => 3;
       } else {
-         plan skip_all => "PDL::GSLSF::BESSEL not installed.";
+	  warn "Warning: $@\n\n";
+         plan skip_all => "PDL::GSLSF modules not installed.";
       }
    } else {
-      plan skip_all => "PDL::GSLSF::BESSEL not compiled.";
+      plan skip_all => "PDL::GSLSF modules not compiled.";
    }
 }
 
-$arg = 5.0;
-$expected = -0.17759677131433830434739701;
+my $arg = 5.0;
+my $expected = -0.17759677131433830434739701;
 
-($y,$err) = gsl_sf_bessel_Jn $arg, 0;
+my ($y,$err) = gsl_sf_bessel_Jn($arg, 0);
 
-print "got $y +- $err\n";
+#print "got $y +- $err\n";
 
-ok abs($y-$expected) < 1e-6;
+ok(abs($y-$expected) < 1e-6,"GSL SF Bessel function");
+
+my $Ylm = gsl_sf_legendre_array(xvals(21)/10-1,'Y',4,-1);
+ok($Ylm->slice("(0)")->uniq->nelem == 1, "Legendre Y00 is constant");
+ok(approx($Ylm->slice("(0),(0)"),0.5/sqrt(3.141592654),1E-6), "Y00 value is corect");

--- a/t/gsl_sf.t
+++ b/t/gsl_sf.t
@@ -15,6 +15,7 @@ BEGIN
 {
    use PDL::Config;
    if ( $PDL::Config{WITH_GSL} ) {
+       my $v = `gsl-config --version`;
        eval "
 	  use PDL::GSLSF::AIRY;
 	  use PDL::GSLSF::BESSEL;
@@ -46,7 +47,8 @@ BEGIN
 	  use PDL::GSLSF::ZETA;
       ";
       unless ($@) {
-         plan tests => 3;
+	  plan tests => 3 if $v>=2.0;
+	  plan tests => 1 if $v<2.0;
       } else {
 	  warn "Warning: $@\n\n";
          plan skip_all => "PDL::GSLSF modules not installed.";
@@ -56,6 +58,7 @@ BEGIN
    }
 }
 
+my $version = `gsl-config --version`;
 my $arg = 5.0;
 my $expected = -0.17759677131433830434739701;
 
@@ -65,6 +68,8 @@ my ($y,$err) = gsl_sf_bessel_Jn($arg, 0);
 
 ok(abs($y-$expected) < 1e-6,"GSL SF Bessel function");
 
-my $Ylm = gsl_sf_legendre_array(xvals(21)/10-1,'Y',4,-1);
-ok($Ylm->slice("(0)")->uniq->nelem == 1, "Legendre Y00 is constant");
-ok(approx($Ylm->slice("(0),(0)"),0.5/sqrt(3.141592654),1E-6), "Y00 value is corect");
+if ($version >= 2.0){
+    my $Ylm = gsl_sf_legendre_array(xvals(21)/10-1,'Y',4,-1);
+    ok($Ylm->slice("(0)")->uniq->nelem == 1, "Legendre Y00 is constant");
+    ok(approx($Ylm->slice("(0),(0)"),0.5/sqrt(3.141592654),1E-6), "Y00 value is corect");
+}

--- a/t/gsl_sf.t
+++ b/t/gsl_sf.t
@@ -15,7 +15,7 @@ BEGIN
 {
    use PDL::Config;
    if ( $PDL::Config{WITH_GSL} ) {
-      eval {
+       eval "
 	  use PDL::GSLSF::AIRY;
 	  use PDL::GSLSF::BESSEL;
 	  use PDL::GSLSF::CLAUSEN;
@@ -44,7 +44,7 @@ BEGIN
 	  use PDL::GSLSF::TRANSPORT;
 	  use PDL::GSLSF::TRIG;
 	  use PDL::GSLSF::ZETA;
-      };
+      ";
       unless ($@) {
          plan tests => 3;
       } else {


### PR DESCRIPTION
This branch adds support for a new calling convention for gsl_sf_ellint_D, deprecates two functions and adds two new ones in gsl_sf_legendre.pd, and adds a very small amount of tests in t/gsl_sf.t.