### PR TITLE
Force modules to call pp_done themselves

### DIFF
--- a/Basic/Bad/bad.pd
+++ b/Basic/Bad/bad.pd
@@ -1458,3 +1458,4 @@ included in the file.
 !WITHOUT!SUBS!
 
 ## End
+pp_done();

--- a/Basic/Gen/PP.pm
+++ b/Basic/Gen/PP.pm
@@ -807,7 +807,13 @@ $::PP_VERBOSE    = 0;
 $PDL::PP::done = 0;  # pp_done has not been called yet
 
 END {
-  pp_done() unless $PDL::PP::done; # make sure we call this
+    #you can uncomment this for testing, but this should remain
+    #commented in production code. This causes pp_done to be called
+    #even when a .pd file aborts with die(), potentially bypassing
+    #problem code when build is re-attempted. Having this commented
+    #means we are a bit more strict: a module must call pp_done in
+    #order to have .xs and .pm files written.
+#  pp_done() unless $PDL::PP::done;
 }
 
 use Carp;


### PR DESCRIPTION
PDL::PP would call pp_done() for a module if it hadn't done so itself, but this could leave a module in an uncertain state if build stopped midway through the .pd file, bypassing the same code that cause the build to fail in the first place. This just makes removes that functionality, so modules have to call pp_done themselves to write the .pm and .xs files.  Only once was this functionality needed in the PDL source, and I fixed that too.