### PR TITLE
Fix two bugs related to reading RICE-compressed FITS images.

### DIFF
--- a/IO/FITS/FITS.pm
+++ b/IO/FITS/FITS.pm
@@ -1512,9 +1512,16 @@ sub _rfits_unpack_zimage($$$) {
 	}
     }
 
+    # Copy the ZNAXIS* keywords to NAXIS*
+    foreach (grep /^NAXIS/,keys %$hdr){
+	if (exists($hdr->{'Z'.$_}) && defined($hdr->{'Z'.$_})){
+	    $hdr->{$_} = $hdr->{'Z'.$_};
+	}
+    }
+
     # Clean up the ZFOO extensions and table cruft
-    for my $k(keys %{$pdl->hdr}) {
-	delete $pdl->hdr->{$k} if(
+    for my $k(keys %{$hdr}) {
+	delete $hdr->{$k} if(
 	    $k=~ m/^Z/ ||
 	    $k eq "TFIELDS" ||
 	    $k =~ m/^TTYPE/ ||


### PR DESCRIPTION
1) The NAXIS* keywords were not replaced with their
ZNAXIS* equivalents, so the NAXIS fields in the header were incorrect.

2) The Z*, TFIELDS, TTYPE*, and TFORM* keywords were deleted from
the wronge header object, so the header of the returned piddle
still had those fields present.