### PR TITLE
Deprecate finite

### DIFF
--- a/Basic/Bad/bad.pd
+++ b/Basic/Bad/bad.pd
@@ -31,6 +31,7 @@ use strict;
 
 # check for bad value support
 use PDL::Config;
+use PDL::Core::Dev;
 my $bvalflag = $PDL::Config{WITH_BADVAL} || 0;
 my $usenan   = $PDL::Config{BADVAL_USENAN} || 0;
 my $bvalPerPdl = $PDL::Config{BADVAL_PER_PDL} || 0;
@@ -182,10 +183,43 @@ sub PDL::copybad { return $_[0]->copy; } # ignore the mask
 
 # _finite in VC++
 if ($^O =~ /MSWin/) {
-pp_addhdr('
+    pp_addhdr('
 #define finite _finite
 #include <float.h>
 ');
+} else
+{ #taken from pdlcore.c.PL. Probably overkill here: could we just do '#define finite isfinite' ?
+    my $finite_inc;
+    my $use_isfinite = 0;
+    foreach my $inc ( qw/ math.h ieeefp.h / )
+    {
+        if ( trylink ('', "#include <$inc>", 'isfinite(3.2);', '' ) ) {
+            $finite_inc = $inc;
+            $use_isfinite = 1;
+            last;
+        }
+        if ( (!defined($finite_inc))  and  trylink ("finite: $inc", "#include <$inc>", 'finite(3.2);','') ) {
+            $finite_inc = $inc;
+        }
+    }
+
+    if ( defined $finite_inc ) {
+	pp_addhdr("
+#include <$finite_inc>
+#define finite(a) (isfinite(a))
+");
+    } else {
+	pp_addhdr('
+            /* Kludgy finite/isfinite because bad.pd was unable to find one in your math library */
+#ifndef finite
+#ifdef isfinite
+#define finite isfinite
+#else
+#define finite(a) (((a) * 0) == (0))
+#endif
+#endif
+');
+    }
 }
 
 pp_add_exported( '',

--- a/Basic/Core/pdlcore.c.PL
+++ b/Basic/Core/pdlcore.c.PL
@@ -67,7 +67,7 @@ print OUT <<'!HEADER!';
 # for 'isfinite' or 'finite', with a preference for 'isfinite' (IEEE recommends this).
 
 if($Config{cc} eq 'cl') {
-  # _finite in CV++ 4.0
+  # _finite in VC++ 4.0
   print OUT <<'FOO';
 #define finite _finite
 #include <float.h>
@@ -86,7 +86,7 @@ FOO
             $finite_inc = $inc;
         }
     }
-    
+
     if ( defined $finite_inc ) {
         print OUT "#include <$finite_inc>\n";
         print OUT "#define finite(a) (isfinite(a))\n";

--- a/Basic/Math/math.pd
+++ b/Basic/Math/math.pd
@@ -147,7 +147,7 @@ double rint (double);
 }
 
 # patch from Albert Chin
-if ($^O =~ /hpux/) {
+if ($^O =~ /hpux|darwin/) {
 pp_addhdr('
 #ifdef isfinite
 #define finite isfinite

--- a/Basic/MatrixOps/matrixops.pd
+++ b/Basic/MatrixOps/matrixops.pd
@@ -24,7 +24,7 @@ pp_addhdr('
 }
 
 # patch from Albert Chin
-if ($^O =~ /hpux/) {
+if ($^O =~ /hpux|darwin/) {
 pp_addhdr('
 #ifdef isfinite
 #define finite isfinite


### PR DESCRIPTION
This branch gets rid of many "finite is deprecated, use isfinite instead" warnings on OS X/clang.  Should hopefully be transparent to other platforms/compilers.