### PR TITLE
Transform badval fix

### DIFF
--- a/Lib/Transform/transform.pd
+++ b/Lib/Transform/transform.pd
@@ -612,7 +612,8 @@ pp_def('map',
         Pars=>'k0()',  # Dummy to set type (should match the type of "in").
         OtherPars=>'SV *in; SV *out; SV *map; SV *boundary; SV *method;
                     SV *big; SV *blur; SV *sv_min; SV *flux; SV *bv',
-        Code=><<'+==EOD_map_c_code==',
+        Code => <<'+==EOD_map_c_code==',
+
 /*
  * Pixel interpolation & averaging code
  *
@@ -634,6 +635,7 @@ pp_def('map',
  PDL_Double *dvec;          /* Residual vector for linearization        */
  PDL_Double *tvec;          /* Temporary floating-point vector          */
  PDL_Double *acc;           /* Threaded accumulator                     */
+ PDL_Double *wgt;           /* Threaded weight accumulator              */
  char   *bounds;            /* Boundary condition packed string         */
  PDL_Indx  *index_stash;    /* Stash to store the opening index of dim sample scans */
  char   method;             /* Method identifier (gets one of 'h','g')  */
@@ -692,6 +694,7 @@ pp_def('map',
                                    ( + sizeof(PDL_Indx)    * 3 * ndims               // ovec, ivec, ibvec
                                      + sizeof(PDL_Double) * (3*ndims)                // dvec, tvec
                                      + sizeof(PDL_Double) * in->dims[ndims]          // acc
+                                     + sizeof(PDL_Double) * in->dims[ndims]          // wgt
                                      + sizeof(PDL_Double) * 3 * ndims*ndims + ndims  // tmp (for PDL_xform_aux)
                                      + sizeof(char) * ndims                          // bounds
                                      + sizeof(PDL_Indx)   * ndims                    // index_stash
@@ -703,7 +706,8 @@ pp_def('map',
  dvec   =    (PDL_Double *)(&(ibvec[ndims]));
  tvec   =                   &(dvec[ndims]);
  acc    =                   &(tvec[ndims]);
- tmp    =                   &(acc[in->dims[ndims]]);
+ wgt    =                   &(acc[in->dims[ndims]]);
+ tmp    =                   &(wgt[in->dims[ndims]]);
  bounds =          (char *)(&(tmp [3*ndims*ndims+ndims]));
  index_stash = (PDL_Indx *) &(bounds[ndims]);
 
@@ -840,7 +844,6 @@ pp_def('map',
 /* Main pixel loop (iterates over pixels in the output plane) */
  do {
    PDL_Indx psize; // Size of the region to accumulate over for this pixel
-   PDL_Double wgt; // Weight accumulator for output
    PDL_Indx i_off; // Offset into the data array of the source PDL
    PDL_Indx j;     // Generic loop index
    char t_vio;     // counter used for truncation boundary violations
@@ -885,10 +888,15 @@ pp_def('map',
      /* Initialize accumulators */
      {
        PDL_Double *ac = acc;
-       for(i=0; i < in->dims[ndims]; i++)
-        *(ac++) = 0.0;
+       for(i=0; i < in->dims[ndims]; i++)	
+         *(ac++) = 0.0;		     
+
      }
-     wgt = 0;
+     {
+       PDL_Double *wg = wgt;
+       for(i=0;i < in->dims[ndims]; i++)
+         *(wg++) = 0.0;
+     }
 
 
      /*
@@ -948,8 +956,8 @@ pp_def('map',
      /* start of each dimensional scan here.  When we finish incrementing     */
      /* through a particular dim, we pull its value back out of the stash.    */
      for(i=0;i<ndims;i++) {
-       index_stash[i] = i_off;
-     }
+       index_stash[i] = i_off; 
+    }
 
      /* The input accumulation loop is the hotspot for the entire operation.        */
      /* We loop over pixels in the region of interest (+/- psize in each dimension) */
@@ -1111,10 +1119,12 @@ pp_def('map',
             $GENERIC() *dat = (($GENERIC() *)(in->data)) + i_off;
             PDL_Indx max = out->dims[ndims];
             for( i=0; i < max; i++ ) {
-              acc[i] += *dat * alpha;
-              dat += in->dimincs[ndims];
+	      if( (badval==0) || (*dat != badval) ) {
+                 acc[i] += *dat * alpha;
+                 dat += in->dimincs[ndims];
+	         wgt[i] += alpha;
+	      }
             }
-            wgt += alpha;
           }
        } /* end of t_vio check (i.e. of input accumulation) */
 
@@ -1193,35 +1203,39 @@ pp_def('map',
 
      {
        PDL_Double *ac = acc;
+       PDL_Double *wg = wgt;
        $GENERIC() *dat = out->data;
 
        /* Calculate output vector offset */
        for(i=0;i<ndims;i++)
          dat += out->dimincs[i] * ovec[i];
 
-       if(wgt) {
-         if(!flux) {
-           /* Flux flag is NOT set -- normal case.  Copy the weighted accumulated data./ */
-           for(i=0; i < out->dims[ndims]; i++) {
-             *dat = *(ac++) / wgt;
-             dat += out->dimincs[ndims];
-           }
-         } else {
-           /* Flux flag is set - scale by the (unpadded) determinant of the Jacobian */
-           PDL_Double det = tmp[ndims*ndims];
-           for(i=0; i < out->dims[ndims]; i++) {
-             *dat = *(ac++) / wgt * det;
-             dat += out->dimincs[ndims];
-           }
+       if(!flux) {
+         /* Flux flag is NOT set -- normal case.  Copy the weighted accumulated data./ */
+         for(i=0; i < out->dims[ndims]; i++) {
+	   if(*wg) {
+              *dat = *(ac++) / *(wg++);
+           } else {
+	      *dat = badval;
+	      ac++; wg++;
+	   }
+              dat += out->dimincs[ndims];
          }
        } else {
-         /* wgt==0 -- no hits */
-         for(i=0;i<out->dims[ndims];i++){
-           *dat = badval;
+         /* Flux flag is set - scale by the (unpadded) determinant of the Jacobian */
+         PDL_Double det = tmp[ndims*ndims];
+         for(i=0; i < out->dims[ndims]; i++) {
+	   if(*wg) {
+              *dat = *(ac++) / *(wg++) * det;
+           } else {
+	      *dat = badval;
+	      ac++; wg++;
+	   }
            dat += out->dimincs[ndims];
-         }
-       }
-     }
+         } /* end of for loop */
+       } /* end of flux flag set conditional */
+     } /* end of convenience block */
+     
      /* End of code for normal pixels */
    } else {
      /* The pixel was ludicrously huge -- just set this pixel to nan */
@@ -1484,6 +1498,14 @@ Pixel values are filtered through a spatially-variable filter tuned to
 the computed Jacobian of the transformation, with radial Gaussian
 rolloff.  This is the most accurate resampling method, in the sense of
 introducing the fewest artifacts into a properly sampled data set.
+This method uses a lookup table to speed up calculation of the Gaussian
+weighting.
+
+=item * G
+
+This method works exactly like 'g' (above), except that the Gaussian
+values are computed explicitly for every sample -- which is considerably
+slower.
 
 =back
 

--- a/Lib/Transform/transform.pd
+++ b/Lib/Transform/transform.pd
@@ -636,6 +636,7 @@ pp_def('map',
  PDL_Double *tvec;          /* Temporary floating-point vector          */
  PDL_Double *acc;           /* Threaded accumulator                     */
  PDL_Double *wgt;           /* Threaded weight accumulator              */
+ PDL_Double *wgt2;          /* Threaded weight accumulator for badval finding   */
  char   *bounds;            /* Boundary condition packed string         */
  PDL_Indx  *index_stash;    /* Stash to store the opening index of dim sample scans */
  char   method;             /* Method identifier (gets one of 'h','g')  */
@@ -667,26 +668,6 @@ pp_def('map',
 
  ndims = map->ndims -1;
 
-  /***************************************************************************/
-  /**  Check that the dimensionalities are consistent.  This is             **/
-  /**  allegedly done already in the perl part, butcan also be done here.   **/
-  /**                                                                       **/
-  /**  if(map->ndims != out->ndims)                                         **/
-  /**   barf("%s", "Bug in map: index dims aren't consistent\n");           **/
-  /**  for(i=0;i<out->ndims-1;i++) {                                        **/
-  /**    static char buf[100];                                              **/
-  /**    if(map->dims[i+1] != out->dims[i]) {                               **/
-  /**      sprintf(buf,"Bug in map: dim %d is %d; expected %d\n",           **/
-  /**                  i,map->dims[i+1],out->dims[i]);                      **/
-  /**      barf("%s", buf);                                                 **/
-  /**    }                                                                  **/
-  /**  }                                                                    **/
-  /**  if(map->dims[0] != in->ndims - 1)                                    **/
-  /**    barf("%s", "Bug in map - index vec - input mismatch\n");           **/
-  /**  if(out->dims[out->ndims-1] != in->dims[in->ndims-1])                 **/
-  /**    barf("%s", "Bug in map:  thread dimension error\n");                **/
-  /***************************************************************************/
-
  /*
   * Allocate all our dynamic workspaces at once
   * */
@@ -695,6 +676,7 @@ pp_def('map',
                                      + sizeof(PDL_Double) * (3*ndims)                // dvec, tvec
                                      + sizeof(PDL_Double) * in->dims[ndims]          // acc
                                      + sizeof(PDL_Double) * in->dims[ndims]          // wgt
+                                     + sizeof(PDL_Double) * in->dims[ndims]          // wgt2
                                      + sizeof(PDL_Double) * 3 * ndims*ndims + ndims  // tmp (for PDL_xform_aux)
                                      + sizeof(char) * ndims                          // bounds
                                      + sizeof(PDL_Indx)   * ndims                    // index_stash
@@ -706,8 +688,9 @@ pp_def('map',
  dvec   =    (PDL_Double *)(&(ibvec[ndims]));
  tvec   =                   &(dvec[ndims]);
  acc    =                   &(tvec[ndims]);
- wgt    =                   &(acc[in->dims[ndims]]);
- tmp    =                   &(wgt[in->dims[ndims]]);
+ wgt    =                   &(acc[in->dims[ndims]]);  // weighting for accumulation
+ wgt2   =                   &(wgt[in->dims[ndims]]);  // weighting for acc, if no bad values were found
+ tmp    =                   &(wgt2[in->dims[ndims]]);
  bounds =          (char *)(&(tmp [3*ndims*ndims+ndims]));
  index_stash = (PDL_Indx *) &(bounds[ndims]);
 
@@ -897,6 +880,11 @@ pp_def('map',
        for(i=0;i < in->dims[ndims]; i++)
          *(wg++) = 0.0;
      }
+     {
+       PDL_Double *wg = wgt2;
+       for(i=0;i < in->dims[ndims]; i++)
+         *(wg++) = 0.0;
+      }	  
 
 
      /*
@@ -908,6 +896,7 @@ pp_def('map',
       *
       * This code matches the incrementation code at the bottom of the accumulation loop
       */
+      
      t_vio = 0; /* truncation-boundary violation count - don't bother if it is nonzero */
      i_off = 0;
      for(i=0;i<ndims; i++) {
@@ -1124,6 +1113,7 @@ pp_def('map',
                  dat += in->dimincs[ndims];
 	         wgt[i] += alpha;
 	      }
+	      wgt2[i] += alpha;  // Accumulate what weight we would have with no bad values
             }
           }
        } /* end of t_vio check (i.e. of input accumulation) */
@@ -1204,6 +1194,7 @@ pp_def('map',
      {
        PDL_Double *ac = acc;
        PDL_Double *wg = wgt;
+       PDL_Double *wg2 = wgt2;
        $GENERIC() *dat = out->data;
 
        /* Calculate output vector offset */
@@ -1211,13 +1202,14 @@ pp_def('map',
          dat += out->dimincs[i] * ovec[i];
 
        if(!flux) {
-         /* Flux flag is NOT set -- normal case.  Copy the weighted accumulated data./ */
+         /* Flux flag is NOT set -- normal case.  Copy the weighted accumulated data. */
          for(i=0; i < out->dims[ndims]; i++) {
-	   if(*wg) {
+	   if(*wg && (*wg2 / *wg) < 1.5 ) {
               *dat = *(ac++) / *(wg++);
+	      wg2++;
            } else {
 	      *dat = badval;
-	      ac++; wg++;
+	      ac++; wg++; wg2++;
 	   }
               dat += out->dimincs[ndims];
          }
@@ -1225,11 +1217,12 @@ pp_def('map',
          /* Flux flag is set - scale by the (unpadded) determinant of the Jacobian */
          PDL_Double det = tmp[ndims*ndims];
          for(i=0; i < out->dims[ndims]; i++) {
-	   if(*wg) {
+	   if(*wg && (*wg2 / *wg) < 1.5 ) {
               *dat = *(ac++) / *(wg++) * det;
+	      wg2++;
            } else {
 	      *dat = badval;
-	      ac++; wg++;
+	      ac++; wg++; wg2++;
 	   }
            dat += out->dimincs[ndims];
          } /* end of for loop */
@@ -1543,8 +1536,7 @@ than 1.0 are silly, because they allow the entire input array to be compressed
 into a region smaller than a single pixel.
 
 Wherever an output pixel would require averaging over an area that is too
-big in input space, it instead gets NaN or the equivalent (bad values are
-not yet supported).
+big in input space, it instead gets NaN or the bad value.
 
 =item phot, photometry, Photometry
 

--- a/Lib/Transform/transform.pd
+++ b/Lib/Transform/transform.pd
@@ -1673,7 +1673,8 @@ sub map {
   $out = PDL::new_from_specification('PDL',$in->type,@odims);
   $out->sethdr($ohdr) if defined($ohdr);
 
-  if($PDL::Bad::Status and $in->badflag()) {
+  if($PDL::Bad::Status) {
+    # set badflag on output all the time if possible, to account for boundary violations
     $out->badflag(1);
   }
 

--- a/Lib/Transform/transform.pd
+++ b/Lib/Transform/transform.pd
@@ -1580,6 +1580,15 @@ pixel.  This flaw is inherent in the assumptions that underly creating
 a Jacobian matrix.  Maybe someone will write code to work around it.
 Maybe that someone is you.
 
+BAD VALUES:
+
+If your PDL was compiled with bad value support, C<map()> supports
+bad values in the data array.  Bad values in the input array are
+propagated to the output array.  The 'g' and 'h' methods will do some
+smoothing over bad values:  if more than 1/3 of the weighted input-array
+footprint of a given output pixel is bad, then the output pixel gets marked
+bad.
+
 =cut
 
 +==EOD_map_doc==


### PR DESCRIPTION
Anti-aliased resampling jobs now support bad values in a meaningful way.  They're ignored in the local averaging kernel, and if enough of the points of each kernel are missing, the output pixel is also marked bad.