### PR TITLE
Change a printf conversion flag for sizeof().

### DIFF
--- a/Basic/Core/pdlapi.c
+++ b/Basic/Core/pdlapi.c
@@ -144,7 +144,7 @@ pdl* pdl_create(int type) {
      it->magic = 0;
      it->hdrsv = 0;
 
-     PDLDEBUG_f(printf("CREATE %p (size=%d)\n",(void*)it,sizeof(pdl)));
+     PDLDEBUG_f(printf("CREATE %p (size=%zu)\n",(void*)it,sizeof(pdl)));
      return it;
 }
 


### PR DESCRIPTION
Using %d was causing a compiler warning, %zu should be better.

This probably doesn't warrant a full pull request, but since it's core code, better to be safe.