### PR TITLE
Handle @INC without . in it for PDL build - Take 2

### DIFF
--- a/Basic/Core/Core.xs
+++ b/Basic/Core/Core.xs
@@ -336,7 +336,7 @@ iscontig(x)
 
 # using "perl" not $^X because that doesn't work on "perl in space"
 # TODO: switching back to $^X since using "perl" is not a viable fix
-INCLUDE_COMMAND: $^X -e "require q{Dev.pm}; PDL::Core::Dev::generate_core_flags()"
+INCLUDE_COMMAND: $^X -e "require q{./Dev.pm}; PDL::Core::Dev::generate_core_flags()"
 
 #if 0
 =begin windows_mmap

--- a/Basic/Core/pdl.h.PL
+++ b/Basic/Core/pdl.h.PL
@@ -6,7 +6,7 @@ use Config;
 use File::Basename qw(&basename &dirname);
 
 # how many variable types (ie PDL_Byte, ...) are there?
-require 'Types.pm';
+require './Types.pm';
 my $ntypes = $#PDL::Types::names;
 my $PDL_DATATYPES = PDL::Types::datatypes_header();
 

--- a/Basic/Core/pdlconv.c.PL
+++ b/Basic/Core/pdlconv.c.PL
@@ -7,9 +7,9 @@ use strict;
 use Config;
 use File::Basename qw(&basename &dirname);
  
-require 'Dev.pm'; PDL::Core::Dev->import;
+require './Dev.pm'; PDL::Core::Dev->import;
 use vars qw( %PDL_DATATYPES );
-require 'Types.pm'; #for typesrtkeys
+require './Types.pm'; #for typesrtkeys
 
 # This forces PL files to create target in same directory as PL file.
 # This is so that make depend always knows where to find PL derivatives.

--- a/Basic/Core/pdlcore.c.PL
+++ b/Basic/Core/pdlcore.c.PL
@@ -6,7 +6,7 @@ use strict;
 use Config;
 use File::Basename qw(&basename &dirname);
 
-require 'Dev.pm'; PDL::Core::Dev->import;
+require './Dev.pm'; PDL::Core::Dev->import;
 use vars qw( %PDL_DATATYPES );
 
 # check for bad value support
@@ -14,7 +14,7 @@ require './Config.pm'; # to load the PDL not the Perl one
 die "No PDL::Config found" unless %PDL::Config;
 my $bvalflag = $PDL::Config{WITH_BADVAL};
 my $usenan = $PDL::Config{BADVAL_USENAN};
-require 'Types.pm';
+require './Types.pm';
 PDL::Types->import(':All');
 
 

--- a/Basic/Core/pdlcore.h.PL
+++ b/Basic/Core/pdlcore.h.PL
@@ -11,7 +11,7 @@ use strict;
 use Config;
 use File::Basename qw(&basename &dirname);
 
-require 'Dev.pm'; PDL::Core::Dev->import;
+require './Dev.pm'; PDL::Core::Dev->import;
 use vars qw( %PDL_DATATYPES );
 
 # version 2 is for versions after PDL 2.1.1
@@ -349,7 +349,7 @@ double NaN_double;
 
     # fortunately it looks like Types.pm.PL is processed before this
     # file
-    require "Types.pm";  # ie PDL::Types
+    require "./Types.pm";  # ie PDL::Types
 
 for (PDL::Types::typesrtkeys()) {
    my $ctype = $PDL::Types::typehash{$_}{ctype};

--- a/Basic/Core/pdlsimple.h.PL
+++ b/Basic/Core/pdlsimple.h.PL
@@ -3,7 +3,7 @@
 use Config;
 use File::Basename qw(&basename &dirname);
 
-require 'Types.pm';
+require './Types.pm';
 my $PDL_DATATYPES = PDL::Types::datatypes_header();
 
 # List explicitly here the variables you want Configure to


### PR DESCRIPTION
In order to compile the master branch of PDL in my system perl (5.24.1, Ubuntu 17.04, x86_64) I had to apply this patch that prepends "./" to `require`'s of modules located in the current directory.

It is similar to the previous one by Todd Rinaldo.