### PR TITLE
Remove 'thresh' option in fitwarp2d.

### DIFF
--- a/Basic/Core/Core.pm
+++ b/Basic/Core/Core.pm
@@ -3155,7 +3155,7 @@ sub PDL::sclr {
 concatenate piddles to N+1 dimensional piddle
 
 Takes a list of N piddles of same shape as argument,
-returns a single piddle of dimension N+1
+returns a single piddle of dimension N+1.
 
 =for example
 
@@ -3185,8 +3185,15 @@ docs will also say this:
 
 The output piddle is set bad if any input piddles have their bad flag set.
 
-Similar functions include L<append|PDL::Primitive/append> and
-L<glue|PDL::Primitive/glue>.
+Similar functions include L<append|PDL::Primitive/append>, which
+appends only two piddles along their first dimension, and
+L<glue|PDL::Primitive/glue>, which can append more than two piddles
+along an arbitary dimension.
+
+Also consider the generic constructor L<pdl|pdl>, which can handle
+piddles of different sizes (with zero-padding), and will return a
+piddle of type 'double' by default, but may be considerably faster (up
+to 10x) than cat.
 
 =cut
 
@@ -3196,7 +3203,7 @@ sub PDL::cat {
 	$@ = '';
 	eval {
 		$res = $_[0]->initialize;
-		$res->set_datatype($_[0]->get_datatype);
+		$res->set_datatype((sort {$b<=>$a} map{$_->get_datatype} @_)[0] );
 
 		my @resdims = $_[0]->dims;
 		for my $i(0..$#_){

--- a/Basic/Core/Dev.pm
+++ b/Basic/Core/Dev.pm
@@ -37,6 +37,8 @@ use English; require Exporter;
                 pdlpp_mkgen
 		 );
 
+my $quotation_mark = $^O =~ /MSWin32/i ? '"' : "'";
+
 # Installation locations
 # beware: whereami_any now appends the /Basic or /PDL directory as appropriate
 
@@ -45,7 +47,6 @@ use English; require Exporter;
 # print STDERR "executing PDL::Core::Dev from",join(',',caller),"\n";
 
 # Return library locations
-
 
 sub PDL_INCLUDE { '"-I'.whereami_any().'/Core"' };
 sub PDL_TYPEMAP { whereami_any().'/Core/typemap.pdl' };
@@ -436,7 +437,7 @@ $pref\$(OBJ_EXT): $pref.c
 
 install ::
 	\@echo "Updating PDL documentation database...";
-	\$(ABSPERLRUN) -e 'exit if \$\$ENV{DESTDIR}; use PDL::Doc; eval { PDL::Doc::add_module(q{$mod}); }; ';
+	\$(ABSPERLRUN) -e ${quotation_mark}exit if \$\$ENV{DESTDIR}; use PDL::Doc; eval { PDL::Doc::add_module(q{$mod}); }; ${quotation_mark};
 |
 	} (@_)
 }

--- a/Basic/Primitive/primitive.pd
+++ b/Basic/Primitive/primitive.pd
@@ -1950,7 +1950,7 @@ pp_def('append',
 
 =for ref
 
-append two or more piddles by concatenating along their first dimensions
+append two piddles by concatenating along their first dimensions
 
 =for example
 
@@ -1958,12 +1958,15 @@ append two or more piddles by concatenating along their first dimensions
  $b = sequence 5;
  $c = $a->append($b);  # size of $c is now (7,4,7) (a jumbo-piddle ;)
 
-C<append> appends two piddles along their first dims. Rest of the dimensions
-must be compatible in the threading sense. Resulting size of first dim is
-the sum of the sizes of the first dims of the two argument piddles -
-ie C<n + m>.
+C<append> appends two piddles along their first dimensions. The rest of the
+dimensions must be compatible in the threading sense. The resulting
+size of the first dimension is the sum of the sizes of the first dimensions
+of the two argument piddles - i.e. C<n + m>.
 
-Similar functions include L<glue|/glue> (below) and L<cat|PDL::Core/cat>.
+Similar functions include L<glue|/glue> (below), which can append more
+than two piddles along an arbitary dimension, and
+L<cat|PDL::Core/cat>, which can append more than two piddles that all
+have the same sized dimensions.
 
 =cut
 
@@ -2003,7 +2006,10 @@ C<glue> is implemented in pdl, using a combination of L<xchg|PDL::Slices/xchg> a
 L<append|append>.  It should probably be updated (one day) to a pure PP
 function.
 
-Similar functions include L<append|/append> (above) and L<cat|PDL::Core/cat>.
+Similar functions include L<append|/append> (above), which appends
+only two piddles along their first dimension, and
+L<cat|PDL::Core/cat>, which can append more than two piddles that all
+have the same sized dimensions.
 
 =cut
 

--- a/Lib/Image2D/image2d.pd
+++ b/Lib/Image2D/image2d.pd
@@ -2448,7 +2448,7 @@ sub PDL::warp2d {
     %}        /* threadloop */
 
     free(poly);
-    free(kernel) ;
+    kernel_free(kernel) ;
 
 ',
     ); # pp_def: warp2d
@@ -2539,7 +2539,7 @@ sub PDL::warp2d_kernel ($) {
     %}
 
     /* free the kernel */
-    free( kernel );
+    kernel_free( kernel );
 
 '); # pp_addpm
 

--- a/Lib/Image2D/image2d.pd
+++ b/Lib/Image2D/image2d.pd
@@ -1765,14 +1765,14 @@ C<FIT> allows you to restrict which terms of the polynomial to fit:
 only those terms for which the FIT piddle evaluates to true will be
 evaluated.  If a 2D piddle is sent in, then it is
 used for the x and y polynomials; otherwise
-C<$fit-E<gt>slice(":,:,(0)")> will be used for C<$px> and
-C<$fit-E<gt>slice(":,:,(1)")> will be used for C<$py>.
+C<< $fit->slice(":,:,(0)") >> will be used for C<$px> and
+C<< $fit->slice(":,:,(1)") >> will be used for C<$py>.
 
 =begin comment
 
 =item THRESH
 
-Remove all singular values whose valus is less than C<THRESH>
+Remove all singular values whose value is less than C<THRESH>
 times the largest singular value.
 
 =end comment

--- a/Lib/Image2D/image2d.pd
+++ b/Lib/Image2D/image2d.pd
@@ -1721,7 +1721,7 @@ a coordinate transformation.
 
 =for usage
 
-  ( $px, $py ) = fitwarp2d( $x, $y, $u, $v, $nf. { options } )
+  ( $px, $py ) = fitwarp2d( $x, $y, $u, $v, $nf, { options } )
 
 Given a set of points in the output plane (C<$u,$v>), find
 the best-fit (using singular-value decomposition) 2D polynomial
@@ -1748,8 +1748,14 @@ Options:
 =for options
 
   FIT     - which terms to fit? default ones(byte,$nf,$nf)
+
+=begin comment
+
+old option, caused trouble
   THRESH  - in svd, remove terms smaller than THRESH * max value
             default is 1.0e-5
+
+=end comment
 
 =over 4
 
@@ -1762,10 +1768,14 @@ used for the x and y polynomials; otherwise
 C<$fit-E<gt>slice(":,:,(0)")> will be used for C<$px> and
 C<$fit-E<gt>slice(":,:,(1)")> will be used for C<$py>.
 
+=begin comment
+
 =item THRESH
 
 Remove all singular values whose valus is less than C<THRESH>
 times the largest singular value.
+
+=end comment
 
 =back
 
@@ -1810,6 +1820,40 @@ terms to fit (C<$nf*$nf> points for the default value of C<FIT>).
    [          1.25 -5.8546917e-18]
   ]
 
+  # A higher-degree polynomial should not affect the answer much, but
+  # will require more control points
+
+  $x = $x->glue(0,pdl(50,12.5, 37.5, 12.5, 37.5));
+  $y = $y->glue(0,pdl(50,12.5, 37.5, 37.5, 12.5));
+  $u = $u->glue(0,pdl(73,20,40,20,40));
+  $v = $v->glue(0,pdl(29,20,40,40,20));
+  ( $px3, $py3 ) = fitwarp2d( $x, $y, $u, $v, 3 );
+  print "px3 =${px3}py3 =$py3";
+  px3 =
+  [
+   [-6.4981162e+08       71034917     -726498.95]
+   [      49902244     -5415096.7      55945.388]
+   [    -807778.46      88457.191     -902.51612]
+  ]
+  py3 =
+  [
+   [-6.2732159e+08       68576392     -701354.77]
+   [      48175125     -5227679.8      54009.114]
+   [    -779821.18      85395.681     -871.27997]
+  ]
+
+  #This illustrates an important point about singular value
+  #decompositions that are used in fitwarp2d: like all SVDs, the
+  #rotation matrices are not unique, and so the $px and $py returned
+  #by fitwarp2d are not guaranteed to be the "simplest" solution.
+  #They do still work, though:
+
+  ($x3,$y3) = applywarp2d($px3,$py3,$u,$v);
+  print approx $x3,$x,1e-4;
+  [1 1 1 1 1 1 1 1 1]
+  print approx $y3,$y;
+  [1 1 1 1 1 1 1 1 1]
+
 =head2 applywarp2d
 
 =for ref
@@ -1828,10 +1872,75 @@ for more information on the format of C<$px> and C<$py>.
 =cut
 
 # use SVD to fit data. Assuming no errors.
-sub _svd ($$$) {
+
+=pod
+
+=begin comment
+
+Some explanation of the following three subroutines (_svd, _mkbasis,
+and fitwarp2d): See Wolberg 1990 (full ref elsewhere in this
+documentation), Chapter 3.6 "Polynomial Transformations".  The idea is
+that, given a set of control points in the input and output images
+denoted by coordinates (x,y) and (u,v), we want to create a polynomial
+transformation that relates u to linear combinations of powers of x
+and y, and another that relates v to powers of x and y.
+
+The transformations used here and by Wolberg differ slightly, but the
+basic idea is something like this.  For each u and each v, define a
+transform:
+
+u = (sum over j) (sum over i) a_{ij} x**i * y**j , (eqn 1)
+v = (sum over j) (sum over i) b_{ij} x**i * y**j . (eqn 2)
+
+We can write this in matrix notation.  Given that there are M control
+points, U is a column vector with M rows.  A and B are vectors containing
+the N coefficients (related to the degree of the polynomial fit).  W
+is an MxN matrix of the basis row-vectors (the x**i y**j).
+
+The matrix equations we are trying to solve are
+U = W A , (eqn 3)
+V = W B . (eqn 4)
+
+We need to find the A and B column vectors, those are the coefficients
+of the polynomial terms in W.  W is not square, so it has no inverse.
+But is has a pseudo-inverse W^+ that is NxM.  We are going to use that
+pseudo-inverse to isolate A and B, like so:
+
+W^+ U = W^+ W A = A (eqn 5)
+W^+ V = W^+ W B = B (eqn 6)
+
+We are going to get W^+ by performing a singular value decomposition
+of W (to use some of the variable names below):
+
+W = $svd_u x SIGMA x $svd_v->transpose (eqn 7)
+W^+ = $svd_v x SIGMA^+ x $svd_u->transpose . (eqn 8)
+
+Here SIGMA is a square diagonal matrix that contains the singular
+values of W that are in the variable $svd_w.  SIGMA^+ is the
+pseudo-inverse of SIGMA, which is calculated by replacing the non-zero
+singular values with their reciprocals, and then taking the transpose
+of the matrix (which is a no-op since the matrix is square and
+diagonal).
+
+So the code below does this:
+
+_mkbasis computes the matrix W, given control coordinates u and v and
+the maximum degree of the polynomial (and the terms to use).
+
+_svd takes the svd of W, computes the pseudo-inverse of W, and then
+multiplies that with the U vector (there called $y). The output of
+_svd is the A or B vector in eqns 5 & 6 above. Rarely is the matrix
+multiplication explicit, unfortunately, so I have added EXPLANATIONs
+below.
+
+=end comment
+
+=cut
+
+sub _svd ($$) {
     my $basis  = shift;
     my $y      = shift;
-    my $thresh = shift;
+#    my $thresh = shift;
 
     # if we had errors for these points, would normalise the
     # basis functions, and the output array, by these errors here
@@ -1839,12 +1948,19 @@ sub _svd ($$$) {
     # perform the SVD
     my ( $svd_u, $svd_w, $svd_v ) = svd( $basis );
 
-    # remove any singular values
-    $svd_w *= ( $svd_w >= ($svd_w->max * $thresh ) );
+    # DAL, 09/2017: the reason for removing ANY singular values, much less
+    #the smallest ones, is not clear. I commented the line below since this
+    #actually removes the LARGEST values in SIGMA^+.
+    # $svd_w *= ( $svd_w >= ($svd_w->max * $thresh ) );
+    # The line below would instead remove the SMALLEST values in SIGMA^+, but I can see no reason to include it either.
+    # $svd_w *= ( $svd_w <= ($svd_w->min / $thresh ) );
 
     # perform the back substitution
-    #
+    # EXPLANATION: same thing as $svd_u->transpose x $y->transpose.
     my $tmp = $y x $svd_u;
+
+    #EXPLANATION: the division by (the non-zero elements of) $svd_w (the singular values) is
+    #equivalent to $sigma_plus x $tmp, so $tmp is now SIGMA^+ x $svd_u x $y
     if ( $PDL::Bad::Status ) {
 	$tmp /= $svd_w->setvaltobad(0.0);
 	$tmp->inplace->setbadtoval(0.0);
@@ -1855,11 +1971,22 @@ sub _svd ($$$) {
 	$tmp *= ( 1 - $mask );
     }
 
-    my $ans = sumover( $svd_v * $tmp );
-
-    return $ans;
+    #EXPLANATION:   $svd_v x SIGMA^+ x $svd_u x $y
+    return sumover( $svd_v * $tmp );
 
 } # sub: _svd()
+
+#_mkbasis returns a piddle in which the k(=j*n+i)_th column is v**j * u**i
+#k=0 j=0 i=0
+#k=1 j=0 i=1
+#k=2 j=0 i=2
+#k=3 j=1 i=0
+# ...
+
+#each row corresponds to a control point
+#and the rows for each of the control points look like this, e.g.:
+# (1) (u) (u**2) (v) (vu) (v(u**2)) (v**2) ((v**2)u) ((v**2)(u**2))
+# and so on for the next control point.
 
 sub _mkbasis ($$$$) {
     my $fit    = shift;
@@ -1896,7 +2023,7 @@ sub PDL::fitwarp2d {
     my $v  = shift;
     my $nf = shift;
 
-    my $opts = PDL::Options->new( { FIT => ones(byte,$nf,$nf), THRESH => 1.0e-5 } );
+    my $opts = PDL::Options->new( { FIT => ones(byte,$nf,$nf) } ); #, THRESH => 1.0e-5 } );
     $opts->options( $_[0] ) if $#_ > -1;
     my $oref = $opts->current();
 
@@ -1906,9 +2033,9 @@ sub PDL::fitwarp2d {
 	unless $npts == $y->nelem and $npts == $u->nelem and $npts == $v->nelem
 	    and $x->getndims == 1 and $y->getndims == 1 and $u->getndims == 1 and $v->getndims == 1;
 
-    my $svd_thresh = $$oref{THRESH};
-    croak "fitwarp2d: THRESH option must be >= 0."
-	if $svd_thresh < 0;
+#    my $svd_thresh = $$oref{THRESH};
+#    croak "fitwarp2d: THRESH option must be >= 0."
+#	if $svd_thresh < 0;
 
     my $fit = $$oref{FIT};
     my $fit_ndim = $fit->getndims();
@@ -1933,20 +2060,22 @@ sub PDL::fitwarp2d {
 	$ncoeff = $ncoeffx > $ncoeffy ? $ncoeffx : $ncoeffy;
     }
 
-    croak "fitwarp2d: number of points must be >= \$ncoeff"
+    croak "fitwarp2d: number of points ($npts) must be >= \$ncoeff ($ncoeff)"
 	unless $npts >= $ncoeff;
 
     # create the basis functions for the SVD fitting
     my ( $basisx, $basisy );
+
     $basisx = _mkbasis( $fitx, $npts, $u, $v );
+
     if ( $fit_ndim == 2 ) {
 	$basisy = $basisx;
     } else {
 	$basisy = _mkbasis( $fity, $npts, $u, $v );
     }
 
-    my $px = _svd( $basisx, $x, $svd_thresh );
-    my $py = _svd( $basisy, $y, $svd_thresh );
+    my $px = _svd( $basisx, $x ); # $svd_thresh);
+    my $py = _svd( $basisy, $y ); # $svd_thresh);
 
     # convert into $nf x $nf element piddles, if necessary
     my $nf2 = $nf * $nf;

--- a/Lib/Image2D/resample.c
+++ b/Lib/Image2D/resample.c
@@ -357,6 +357,11 @@ generate_interpolation_kernel(char * kernel_type)
 
 } /* generate_interpolation_kernel() */
 
+void kernel_free( void *p ) {
+#undef free
+free( p );
+}
+
 /***********
  *** END ***
  ***********/

--- a/Lib/Image2D/resample.h
+++ b/Lib/Image2D/resample.h
@@ -39,4 +39,7 @@ poly2d_compute( int ncoeff, double *c, double u, double *vpow );
 double   *
 generate_interpolation_kernel(char * kernel_type);
 
+void
+kernel_free(void *p);
+
 #endif

--- a/Perldl2/pdl2
+++ b/Perldl2/pdl2
@@ -3,7 +3,7 @@
 BEGIN {
    $ENV{DEVEL_REPL_PROFILE} = 'PDL::Perldl2::Profile::Perldl2';
 
-   # This should be based on 
+   # This should be based on
    $HOME = $ENV{HOME};             # Useful in shell
    if ($^O =~ /win32/i and
       (! defined($HOME)) or
@@ -21,6 +21,7 @@ BEGIN {
    eval " use Devel::REPL $minversion ";
    if ($@) {
       my ($perldl) = $0;
+      $perldl =~ s/pdl2\.bat$/perldl.bat/;
       $perldl =~ s/pdl2$/perldl/;
       warn "pdl2: Devel::REPL version $minversion not found, running '$perldl' instead...\n";
       do $perldl;
@@ -46,8 +47,8 @@ Use PDL interactively:
   %> pdl2
 
   pdl> $a = sequence(10)  # or any other perl or PDL command
-  
-  pdl> print "\$a = $a\n"; 
+
+  pdl> print "\$a = $a\n";
   $a = [0 1 2 3 4 5 6 7 8 9]
 
 =head1 DESCRIPTION

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ build_script:
   - perl Makefile.PL
 
 test_script:
-  - dmake test
+  - gmake test

--- a/t/core.t
+++ b/t/core.t
@@ -7,13 +7,13 @@ use strict;
 use Test::More;
 
 BEGIN {
-    # if we've got this far in the tests then 
+    # if we've got this far in the tests then
     # we can probably assume PDL::LiteF works!
     #
     eval {
         require PDL::LiteF;
     } or BAIL_OUT("PDL::LiteF failed: $@");
-    plan tests => 70;
+    plan tests => 75;
     PDL::LiteF->import;
 }
 $| = 1;
@@ -114,13 +114,13 @@ $b = pdl( long, $a );
 $c = pdl( long, [ 2, 0, 3, 4 ] )->reshape(2,2);
 ok all( $b == $c ), "undef converted to 0 (long)";
 
-do { 
+do {
     local($PDL::undefval) = -999;
     $a = [ [ 2, undef ], [3, 4 ] ];
     $b = pdl( $a );
     $c = pdl( [ 2, -999, 3, 4 ] )->reshape(2,2);
     ok all( $b == $c ), "undef converted to -999 (dbl)";
-    
+
     $b = pdl( long, $a );
     $c = pdl( long, [ 2, -999, 3, 4 ] )->reshape(2,2);
     ok all( $b == $c ), "undef converted to -999 (long)";
@@ -138,16 +138,16 @@ TODO: {
 
    # pdl of mixed-dim pdls: pad within a dimension
    $a = pdl( zeroes(5), ones(3) );
-   ok all($a == pdl([0,0,0,0,0],[1,1,1,0,0])),"Piddlifying two piddles catenates them and pads to length" or diag("a=$a\n");
+   ok all($a == pdl([0,0,0,0,0],[1,1,1,0,0])),"Piddlifying two piddles concatenates them and pads to length" or diag("a=$a\n");
 }
-   
+
 # pdl of mixed-dim pdls: pad a whole dimension
 $a = pdl( [[9,9],[8,8]], xvals(3)+1 );
-ok all($a == pdl([[[9,9],[8,8],[0,0]] , [[1,0],[2,0],[3,0]] ])),"can catenate mixed-dim piddles" or diag("a=$a\n");
+ok all($a == pdl([[[9,9],[8,8],[0,0]] , [[1,0],[2,0],[3,0]] ])),"can concatenate mixed-dim piddles" or diag("a=$a\n");
 
 # pdl of mixed-dim pdls: a hairier case
 $c = pdl [1], pdl[2,3,4], pdl[5];
-ok all($c == pdl([[[1,0,0],[0,0,0]],[[2,3,4],[5,0,0]]])),"Can catenate mixed-dim piddles: hairy case" or diag("c=$c\n");
+ok all($c == pdl([[[1,0,0],[0,0,0]],[[2,3,4],[5,0,0]]])),"Can concatenate mixed-dim piddles: hairy case" or diag("c=$c\n");
 
 # same thing, with undefval set differently
 do {
@@ -161,19 +161,19 @@ eval {$a = zeroes(2,0,1);};
 ok(!$@,"zeroes accepts empty PDL specification");
 
 eval { $b = pdl($a,sequence(2,0,1)); };
-ok((!$@ and all(pdl($b->dims) == pdl(2,0,1,2))), "catenating two empties gives an empty");
+ok((!$@ and all(pdl($b->dims) == pdl(2,0,1,2))), "concatenating two empties gives an empty");
 
 eval { $b = pdl($a,sequence(2,1,1)); };
-ok((!$@ and all(pdl($b->dims) == pdl(2,1,1,2))), "catenating an empty and a nonempty treats the empty as a filler");
+ok((!$@ and all(pdl($b->dims) == pdl(2,1,1,2))), "concatenating an empty and a nonempty treats the empty as a filler");
 
 eval { $b = pdl($a,5) };
-ok((!$@ and all(pdl($b->dims)==pdl(2,1,1,2))), "catenating an empty and a scalar on the right works");
-ok( all($b==pdl([[[0,0]]],[[[5,0]]])), "catenating an empty and a scalar on the right gives the right answer");
+ok((!$@ and all(pdl($b->dims)==pdl(2,1,1,2))), "concatenating an empty and a scalar on the right works");
+ok( all($b==pdl([[[0,0]]],[[[5,0]]])), "concatenating an empty and a scalar on the right gives the right answer");
 
 eval { $b = pdl(5,$a) };
-ok((!$@ and all(pdl($b->dims)==pdl(2,1,1,2))), "catenating an empty and a scalar on the left works");
-ok( all($b==pdl([[[5,0]]],[[[0,0]]])), "catenating an empty and a scalar on the left gives the right answer");
-    
+ok((!$@ and all(pdl($b->dims)==pdl(2,1,1,2))), "concatenating an empty and a scalar on the left works");
+ok( all($b==pdl([[[5,0]]],[[[0,0]]])), "concatenating an empty and a scalar on the left gives the right answer");
+
 # end
 
 # cat problems
@@ -211,6 +211,16 @@ ok(!$@, 'cat(pdl(1),pdl(2,3)) succeeds');
 ok( ($a->ndims==2 and $a->dim(0)==2 and $a->dim(1)==2), 'weird cat case has the right shape');
 ok( all( $a == pdl([1,1],[2,3]) ), "cat does the right thing with catting a 0-pdl and 2-pdl together");
 $@='';
+
+my $by=xvals(byte,5)+253;
+my $so=xvals(short,5)+32766;
+my $lo=xvals(long,5)+32766;
+my $fl=float(xvals(5)+0.2);
+my @list = ($lo,$so,$fl,$by);
+my $c2 = cat(@list);
+is($c2->type,'float','concatentating different datatypes returns the highest type');
+my $i=0;
+map{ ok(all($_==$list[$i]),"cat/dog symmetry for values ($i)"); $i++; }$c2->dog;
 
 # new_or_inplace
 $a = sequence(byte,5);


### PR DESCRIPTION
Singular-value decomposition of the basis vectors can return
singular values that differ by 8--10 orders of magnitude. The
default value of thresh (1e-5) would discard several of these smaller
values.  That's a problem because the _inverses_ of the singular
values are actually used to produce the solution in _svd. Discarding
the largest singular values didn't seem to help either. Since it
wasn't entirely clear why some of the singular values were being
discarded, I commented out that line of code, and the associated
documentation, so now we keep all of the singular values.

I also added a detailed explanation of what fitwarp2d, _svd, and
_mkbasis actually do.  And of course, some tests.

If somebody with a lot of linear algebra experience is convinced
of a a good reason to discard some of these singular values, we
can revisit this (hence why I haven't removed the code, just
commented it out for now).