### PR TITLE
Change from Sourceforge to GitHub

### DIFF
--- a/Basic/Core/pdlcore.c.PL
+++ b/Basic/Core/pdlcore.c.PL
@@ -1056,7 +1056,7 @@ PDL_Indx pdl_kludge_copy_$type(PDL_Indx poff, // Offset into the dest data array
   /* Can't copy into a level deeper than the number of dims in the output PDL */
   if(level > ndims ) {
     fprintf(stderr,"pdl_kludge_copy: level=%d; ndims=%"IND_FLAG"\\n",level,ndims);
-    croak("Internal error - please submit a bug report at http://sourceforge.net/projects/pdl/:\\n  pdl_kludge_copy: Assertion failed; ndims-1-level (%"IND_FLAG") < 0!.",ndims-1-level);
+    croak("Internal error - please submit a bug report at https://github.com/PDLPorters/pdl/issues:\\n  pdl_kludge_copy: Assertion failed; ndims-1-level (%"IND_FLAG") < 0!.",ndims-1-level);
   }
 
   if(level >= ndims - 1) {
@@ -1151,7 +1151,7 @@ PDL_Indx pdl_kludge_copy_$type(PDL_Indx poff, // Offset into the dest data array
 
       print OUT <<"!WITH!SUBS!";
     default:
-      croak("Internal error - please submit a bug report at http://sourceforge.net/projects/pdl/:\\n  pdl_kludge_copy: unknown datatype of %d.",(int)(source_pdl->datatype));
+      croak("Internal error - please submit a bug report at https://github.com/PDLPorters/pdl/issues:\\n  pdl_kludge_copy: unknown datatype of %d.",(int)(source_pdl->datatype));
       break;
     }
 

--- a/Basic/Pod/FAQ.pod
+++ b/Basic/Pod/FAQ.pod
@@ -390,8 +390,8 @@ and pdl-devel was called 'pdl-porters'.
 |------------|-------------------------------------------------------|
 |1996 - 2004 | http://www.xray.mpe.mpg.de/mailing-lists/perldl/      |
 |1997 - 2004 | http://www.xray.mpe.mpg.de/mailing-lists/pdl-porters/ |
-|2005 - 2015 | perldl@jach lost???                                   |
-|2005 - 2015 | pdl-porters@jach lost???                              |
+|2005 - 2015 | http://perldl.jach.hawaii.narkive.com/                |
+|2005 - 2015 | http://pdl-porters.jach.hawaii.narkive.com/           |
 |2015 -      | https://sourceforge.net/p/pdl/mailman/pdl-general/    |
 |2015 -      | https://sourceforge.net/p/pdl/mailman/pdl-devel/      |
 |--------------------------------------------------------------------|

--- a/Basic/Pod/FAQ.pod
+++ b/Basic/Pod/FAQ.pod
@@ -639,7 +639,7 @@ See L<Question 3.2|"Q: 3.2 Are there other PDL information sources on the Intern
 The first thing you should do is to read the Git documentation and
 learn the basics about Git. There are many sources available online.
 It is very important that you use Git "best practice", with branches,
-but fortunately this is very easy! Here are the basics:
+but fortunately this is very easy! Here are the basics.
 
 Make sure your copy is up to date with the main repo:
 
@@ -655,16 +655,16 @@ Commit your changes locally:
    git add <file1> <file2> ...
    git commit
 
-or combine these two with 
+or combine these two with:
 
    git commit -a
 
 Test the PDL before you push it to the main repository.  If the
-code is broken for you, then it is most likely broken for others
+code is broken for you, then it is most likely broken for others.
 Luckily, the rest of this process will test that automatically to help
 you catch such errors.
 
-Then update the shared repository with your changes
+Then update the shared repository with your changes:
 
    git push -u origin mybranch-name
 

--- a/Basic/Pod/FAQ.pod
+++ b/Basic/Pod/FAQ.pod
@@ -374,9 +374,8 @@ assistance with PDL related problems, etc.
 If you are interested in all the technical details of the ongoing PDL
 development you can join the pdl-devel mailing list.
 
-Subscription and current archive links to both mailing lists can be found at
-
-    http://pdl.perl.org/?page=mailing-lists
+Subscription and current archive links to both mailing lists can be
+found at L<http://pdl.perl.org/?page=mailing-lists>.
 
 Cross-posting between these lists should be avoided unless there is a
 I<very> good reason for doing that.

--- a/Basic/Pod/FAQ.pod
+++ b/Basic/Pod/FAQ.pod
@@ -261,7 +261,7 @@ assist you in porting PDL to a new system.
 
 PDL is available as source distribution in the 
 I<Comprehensive Perl Archive Network> (or CPAN) and from the
-sourceforge.net project page at L<https://sourceforge.net/projects/pdl/files/>.
+GitHub project page at L<https://github.com/PDLPorters/pdl>.
 The CPAN archives contains not only the PDL distribution but
 also just about everything else that is Perl-related.  CPAN is
 mirrored by dozens of sites all over the world.  The main site
@@ -367,29 +367,34 @@ pages).
 
 =back
 
-If you are interested in PDL in general you can join the PDL mailing
-list pdl-general@lists.sourceforge.net. This is a forum to discuss programming
-issues in PDL, report bugs, seek assistance with PDL related problems,
-etc. To subscribe, fill out the form at
-L<http://lists.sourceforge.net/lists/listinfo/pdl-general> .
-
-A searchable archive and a hypertext version of the traffic on this
-list (1997-2004) can be found at
-L<http://www.xray.mpe.mpg.de/mailing-lists/perldl/> . More recent
-messages (since June 2005) can be found at TBD.
+If you are interested in PDL in general you can join the pdl-general mailing
+list. This is a forum to discuss programming issues in PDL, report bugs, seek
+assistance with PDL related problems, etc.
 
 If you are interested in all the technical details of the ongoing PDL
-development you can join the PDL developers mailing list
-pdl-devel@lists.sourceforge.net . To subscribe, fill out the form at
-L<http://lists.sourceforge.net/lists/listinfo/pdl-devel> .
+development you can join the pdl-devel mailing list.
 
-A searchable archive and a hypertext version
-of the traffic on this list (1997-2004) can be found at 
-L<http://www.xray.mpe.mpg.de/mailing-lists/pdl-porters/> . More recent messages 
-(since June 2005) can be found at TBD
+Subscription and current archive links to both mailing lists can be found at
+
+    http://pdl.perl.org/?page=mailing-lists
 
 Cross-posting between these lists should be avoided unless there is a
 I<very> good reason for doing that.
+
+The PDL project, begun in the late 1990s, has undergone considerable evolution
+since that time, and the support for it has as well. Thus mailing-list
+archives are in several places.  Originally pdl-general was called 'perldl',
+and pdl-devel was called 'pdl-porters'.
+
+|Time Period | URL                                                   |
+|------------|-------------------------------------------------------|
+|1996 - 2004 | http://www.xray.mpe.mpg.de/mailing-lists/perldl/      |
+|1997 - 2004 | http://www.xray.mpe.mpg.de/mailing-lists/pdl-porters/ |
+|2005 - 2015 | perldl@jach lost???                                   |
+|2005 - 2015 | pdl-porters@jach lost???                              |
+|2015 -      | https://sourceforge.net/p/pdl/mailman/pdl-general/    |
+|2015 -      | https://sourceforge.net/p/pdl/mailman/pdl-devel/      |
+|--------------------------------------------------------------------|
 
 
 =head2 Q: 3.3    What is the current version of PDL ?  
@@ -601,9 +606,9 @@ Assume you have Git installed on your system and want to download the
 project source code into the directory C<PDL>. To get read-only access
 to the repository, you type at the command line
 
-   git clone git://git.code.sf.net/p/pdl/code pdl-code
+   git clone git://github.com/PDLPorters/pdl PDL
 
-For official PDL developers, to get read/write access to the repository
+NEEDS updating (sf_to_gh): For official PDL developers, to get read/write access to the repository
 type at the command line
 
    git clone ssh://USERNAME@git.code.sf.net/p/pdl/code pdl-code
@@ -612,13 +617,11 @@ type at the command line
 =head2 Q: 4.10   I had a problem with the Git version, how do I check if someone has submitted a patch?  
 
 
-The Sourceforge system contains a patch-manager which contains patches
-that have not yet been applied to the distribution. This can be
-accessed via the Tickets menu at PDL's Sourceforge project page
-L<http://sourceforge.net/projects/pdl> .
+The best way is to check L<https://github.com/PDLPorters/pdl/pulls> to see if
+somebody has submitted a pull request related to your problem.
 
 In addition, if you are not subscribing to the mailing list,
-check the archive of the C<pdl-porters> and C<perldl> mailing lists.
+check the archive of the C<pdl-devel> and C<pdl-general> mailing lists.
 See L<Question 3.2|"Q: 3.2 Are there other PDL information sources on the Internet?"> for details.
 
 
@@ -648,7 +651,7 @@ and they won't be happy to have their recent PDL fail to build!
 NOTE: git makes it very easy to maintain a separate branch of
 development.  [ TBD, provide information on how ].
 
-Then update the shared repository (at SF.net) with your changes
+Then update the shared repository with your changes
 
    git push origin master
 

--- a/Basic/Pod/FAQ.pod
+++ b/Basic/Pod/FAQ.pod
@@ -606,13 +606,22 @@ Assume you have Git installed on your system and want to download the
 project source code into the directory C<PDL>. To get read-only access
 to the repository, you type at the command line
 
-   git clone git://github.com/PDLPorters/pdl PDL
+   git clone git://github.com/PDLPorters/pdl
 
-NEEDS updating (sf_to_gh): For official PDL developers, to get read/write access to the repository
+If you wish to submit changes to PDL, you should "fork" the repository
+from L<https://github.com/PDLPorters/pdl>, then clone your fork in the
+normal fashion.
+
+To become an official PDL developer, you will need to be added to the
+GitHub "PDLPorters" organisation.
+
+For official PDL developers, to get read/write access to the repository
 type at the command line
 
-   git clone ssh://USERNAME@git.code.sf.net/p/pdl/code pdl-code
+   git clone git://github.com/PDLPorters/pdl
 
+They can still use their own fork; at least one active developer uses
+that model rather than branches on the main repository.
 
 =head2 Q: 4.10   I had a problem with the Git version, how do I check if someone has submitted a patch?  
 
@@ -630,9 +639,19 @@ See L<Question 3.2|"Q: 3.2 Are there other PDL information sources on the Intern
 
 The first thing you should do is to read the Git documentation and
 learn the basics about Git. There are many sources available online.
-But here are the basics:
+It is very important that you use Git "best practice", with branches,
+but fortunately this is very easy! Here are the basics:
 
-Before you upload your changes, commit them to YOUR repository
+Make sure your copy is up to date with the main repo:
+
+   git checkout master
+   git pull --rebase # rebase in case you wrongly changed your own master
+
+Make a branch:
+
+   git checkout -b mybranch-name
+
+Commit your changes locally:
 
    git add <file1> <file2> ...
    git commit
@@ -641,21 +660,25 @@ or combine these two with
 
    git commit -a
 
-Then pull in any changes others have made
-
-   git pull origin
-
 Test the PDL before you push it to the main repository.  If the
 code is broken for you, then it is most likely broken for others
-and they won't be happy to have their recent PDL fail to build!
-NOTE: git makes it very easy to maintain a separate branch of
-development.  [ TBD, provide information on how ].
+Luckily, the rest of this process will test that automatically to help
+you catch such errors.
 
 Then update the shared repository with your changes
 
-   git push origin master
+   git push -u origin mybranch-name
 
+This will still leave your changes on a branch, but this is good. Now
+go to the GitHub page, L<https://github.com/PDLPorters/pdl>. It will
+ask you whether you want to make a "pull request" - you do. Follow the
+prompts. This will then initiate the automated "continuous integration"
+tests, on Linux and Windows, with various versions of Perl, with various
+compilers. You will also want to get at least one other developer to
+review your changes.
 
+Once this review process is successfully completed, you can merge your
+changes to the master branch!
 
 =head1 PDL JARGON
 

--- a/Basic/SourceFilter/NiceSlice.pm
+++ b/Basic/SourceFilter/NiceSlice.pm
@@ -1104,12 +1104,9 @@ the bottom.
 
 Feedback and bug reports are welcome. Please include an example
 that demonstrates the problem. Log bug reports in the PDL
-issues tracker at
-
-  https://github.com/PDLPorters/pdl/issues
-
+issues tracker at L<https://github.com/PDLPorters/pdl/issues>
 or send them to the pdl-devel mailing list
-(see http://pdl.perl.org/?page=mailing-lists).
+(see L<http://pdl.perl.org/?page=mailing-lists>).
 
 
 =head1 COPYRIGHT

--- a/Basic/SourceFilter/NiceSlice.pm
+++ b/Basic/SourceFilter/NiceSlice.pm
@@ -1104,12 +1104,12 @@ the bottom.
 
 Feedback and bug reports are welcome. Please include an example
 that demonstrates the problem. Log bug reports in the PDL
-bug database at
+issues tracker at
 
-  http://sourceforge.net/p/pdl/bugs/
+  https://github.com/PDLPorters/pdl/issues
 
 or send them to the pdl-devel mailing list
-E<lt>pdl-devel@lists.sourceforge.netE<gt>.
+(see http://pdl.perl.org/?page=mailing-lists).
 
 
 =head1 COPYRIGHT

--- a/Bugs.pod
+++ b/Bugs.pod
@@ -148,15 +148,15 @@ Patches can be submitted in several ways, in order of decreasing preference:
 
 =item 1
 
-	Fork the pdl repository on GitHub, make and test your changes, and submit a pull request;
+Fork the pdl repository on GitHub, make and test your changes, and submit a pull request;
 
 =item 2
 
-	Edit (or suggesting an edit to) the files in-place on GitHub;
+Edit (or suggesting an edit to) the files in-place on GitHub;
 
 =item 3
 
-	Email a patch to the pdl-devel mailing list.
+Email a patch to the pdl-devel mailing list.
 
 =back
 

--- a/Bugs.pod
+++ b/Bugs.pod
@@ -53,20 +53,14 @@ is definitely not readily searchable.
 
 =head1 REPORTING BUGS
 
-Please submit bug reports via the sourceforge bug tracker
-interface at
+Please submit bug reports via the GitHub issue tracker at
 
-   http://sourceforge.net/p/pdl/bugs/
+   https://github.com/PDLPorters/pdl/issues
 
 where you can review the previously submitted bug reports.
-Click on C<Create Ticket> to generate a bug report.  If you do not
-already have a sourceforge.net account, you will need to
-get one to submit the report:
-
-   http://sourceforge.net/account/registration/
-
-Please provide a way for the PDL developers to contact you
-regarding the problem.
+Click on C<New issue> to generate a bug report.  If you do not
+already have a GitHub account, you will need to
+create one to submit the report.
 
 Try to include any information you think might help someone
 isolate, reproduce, and fix your problem.
@@ -129,7 +123,7 @@ A patch against the latest released version of this distribution which fixes thi
 
 Alternatively, send an e-mail report with the above
 information (including the output of C<perldl -V>)
-to C<pdl-devel@lists.sourceforge.net>. See
+to the pdl-devel mailing list. See
 
    http://pdl.perl.org/?page=mailing-lists
 
@@ -159,17 +153,30 @@ L<http://pdl.perl.org> which usually gives the best results.
 
 =head1 PATCHES
 
-Patches can be sent to the pdl-devel mailing list
-(see above) or can be directly submitted to the
-patch manager
+Patches can be submitted in several ways, in order of decreasing preference:
 
-   http://sourceforge.net/p/pdl/patches/
+=over 4
+
+=item 1
+
+	Fork the pdl repository on GitHub, make and test your changes, and submit a pull request;
+
+=item 2
+
+	Edit (or suggesting an edit to) the files in-place on GitHub;
+
+=item 3
+
+	Email a patch to the pdl-devel mailing list.
+
+=back
 
 Patches should be made against the latest released
 PDL or, ideally, against the current git sources
 which you can browse and check out at
 
-   git://git.code.sf.net/p/pdl/code
+   https://github.com/PDLPorters/pdl
+   git://github.com/PDLPorters/pdl.git
 
 Thanks,
 The PDL developers.

--- a/Bugs.pod
+++ b/Bugs.pod
@@ -33,9 +33,8 @@ I<is almost always> the list to post to for PDL problems.
 The pdl-devel list is I<specifically> for PDL development
 and often contains discussions of a rather technical nature
 relating to PDL internals.  This is I<not> the list for
-general PDL discussion or questions.
-
-   http://pdl.perl.org/?page=mailing-lists
+general PDL discussion or questions:
+L<http://pdl.perl.org/?page=mailing-lists>.
 
 B<NOTE>: Both pdl-general and pdl-devel are read by the PDL
 developers so you don't save time or increase the probability
@@ -54,8 +53,7 @@ is definitely not readily searchable.
 =head1 REPORTING BUGS
 
 Please submit bug reports via the GitHub issue tracker at
-
-   https://github.com/PDLPorters/pdl/issues
+L<https://github.com/PDLPorters/pdl/issues>.
 
 where you can review the previously submitted bug reports.
 Click on C<New issue> to generate a bug report.  If you do not
@@ -124,9 +122,7 @@ A patch against the latest released version of this distribution which fixes thi
 Alternatively, send an e-mail report with the above
 information (including the output of C<perldl -V>)
 to the pdl-devel mailing list. See
-
-   http://pdl.perl.org/?page=mailing-lists
-
+L<http://pdl.perl.org/?page=mailing-lists>
 for info on how to subscribe to this list.
 
 
@@ -134,18 +130,11 @@ for info on how to subscribe to this list.
 
 BEFORE you report a bug make sure you got the latest
 release version of PDL, always available from CPAN,
-check
+check L<http://search.cpan.org/search?dist=PDL>.
 
-   http://search.cpan.org/search?dist=PDL
-
-Also, you can check the FAQ at
-
-   http://pdl.perl.org/?docs=FAQ&title=PDL::FAQ
-
+Also, you can check the FAQ at L<http://pdl.perl.org/?docs=FAQ&title=PDL::FAQ>.
 and the mailing list archives for hints. You can find links to the
-searchable archives at 
-
-   http://pdl.perl.org/?page=mailing-lists
+searchable archives at L<http://pdl.perl.org/?page=mailing-lists>.
 
 and there is a Google enable search box on the top right of
 L<http://pdl.perl.org> which usually gives the best results.
@@ -173,10 +162,7 @@ Patches can be submitted in several ways, in order of decreasing preference:
 
 Patches should be made against the latest released
 PDL or, ideally, against the current git sources
-which you can browse and check out at
-
-   https://github.com/PDLPorters/pdl
-   git://github.com/PDLPorters/pdl.git
+which you can browse and check out at L<https://github.com/PDLPorters/pdl>.
 
 Thanks,
 The PDL developers.

--- a/DEVELOPMENT
+++ b/DEVELOPMENT
@@ -5,15 +5,15 @@ not be confused with the latest public release
 which will always be available from CPAN (if you
 don't know what that is check the FAQ).
 
-Public Git repository at sourceforge.net
+Public Git repository
 --------------------------------------------
 
 From version PDL-2.4.4 onwards the source
 distribution is in a publicly accessible Git
-repository. The project is hosted at the
-sourceforge site at
+repository. From version PDL-2.019 onwards the
+project is hosted at the GitHub site at
 
-  http://sourceforge.net/projects/pdl/
+  https://github.com/PDLPorters/pdl
 
 Starting from the above URL you will find
 directions on how to check out the current
@@ -78,7 +78,7 @@ access to the PDL Git repository.
    should be able to help.)
   
 
-PDL Developer Recommended Workflow:
+(sf_to_gh)PDL Developer Recommended Workflow:
 -----------------------------------
 The actual workflow is a little more complicated. This is because
 GitHub also hosts a mirror of PDL's SF repository, to enable automatic

--- a/DEVELOPMENT
+++ b/DEVELOPMENT
@@ -15,15 +15,7 @@ project is hosted at the GitHub site at
 
   https://github.com/PDLPorters/pdl
 
-Starting from the above URL you will find
-directions on how to check out the current
-sources, browse the Git repository online, etc.
-
-If you would like to actively contribute to PDL
-development don't hesitate to contact one of the
-project admins (listed at the above URL) to apply
-for write access to the repository. We strongly
-believe in the power of open source development!
+See Basic/Pod/FAQ.pod section 4.9 for instructions on this.
 
 If you do not know how to use Git try 'man git'
 or have a look at some of the online tutorials
@@ -78,40 +70,10 @@ access to the PDL Git repository.
    should be able to help.)
   
 
-(sf_to_gh)PDL Developer Recommended Workflow:
+PDL Developer Recommended Workflow:
 -----------------------------------
-The actual workflow is a little more complicated. This is because
-GitHub also hosts a mirror of PDL's SF repository, to enable automatic
-multi-platform build checks.
 
-If you are just starting out you need to clone the repository:
-
- $ git clone ssh://your_sf_username@git.code.sf.net/p/pdl/code pdl-code
-
-Or if you already have a repository and haven't updated in awhile, do that,
-and follow the rest of the workflow below:
-
- $ git pull origin master			#update local repository
- $ git checkout -b problembranch		#create a local branch (use a more descriptive name!)
- #fix a problem
- $ git add filename(s)				#add files to staging area
- $ git commit					#commit the changes to the local branch
- $ git push origin problembranch		#push the branch to SF
- #after a few minutes, log into GitHub, go to problembranch and initiate a pull request
- #(or ask somebody to do it for you if you don't have a GitHub account).
- #Wait for the automatic build tests to run and pass.
- #Wait for somebody to look at and approve the code if it is complicated.
- #Do NOT merge and delete the branch on GitHub (it will get restored
- #the next time the SF repository is mirrored).
- $ git rebase master				#rebase the branch onto master
- $ git checkout master				#still rebasing
- $ git merge problembranch --ff-only		#finally done rebasing
- $ git push origin master 			#push to SF
- $ git push origin :problembranch		#delete the remote branch
- $ git branch -d problembranch			#delete the local branch
-
-You have just created, pushed, checked, rebased, and deleted a branch.
-
+See Basic/Pod/FAQ.pod section 4.11 for instructions on this.
 
 PDL Developer Notes:
 --------------------

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -468,11 +468,11 @@ my %makefile_hash = (
               'META_MERGE' => {
                  resources => {
                     homepage => 'http://pdl.perl.org/',
-                    bugtracker  => 'http://sourceforge.net/p/pdl/bugs/',
+                    bugtracker  => 'https://github.com/PDLPorters/pdl/issues',
                     repository  => {
-                       url => 'git://git.code.sf.net/p/pdl/code',
+                       url => 'git://github.com/PDLPorters/pdl.git',
                        type => 'git',
-                       web => 'http://sourceforge.net/p/pdl/code/ci/master/tree/',
+                       web => 'https://github.com/PDLPorters/pdl',
                     },
                  },
                  no_index => { file => ['Doc/scantree.pl'] }

--- a/README
+++ b/README
@@ -82,9 +82,9 @@ basic examples of what you can do.
 
 Bug Reports
 -----------
-You can check the existing PDL bugs on sourceforge at
+You can check the existing PDL bugs on GitHub at
 
-	http://sourceforge.net/p/pdl/bugs/
+	https://github.com/PDLPorters/pdl/issues
 
 The mailing list archives can be searched/read at
 
@@ -96,11 +96,8 @@ not sure what you have is a bug or not.  For example, the list
 is the place to go for install problems.
 
 If you need to post a problem report, and after checking with
-the perldl list that it *is* a bug, please use the sourceforge.net
-tracker system following the guidance in the BUGS file:
-
-	http://sourceforge.net/p/pdl/bugs/
-
+the pdl-general list that it *is* a bug, please use the GitHub issue
+tracker system following the guidance in the BUGS file.
 
 
 Notes


### PR DESCRIPTION
Building on the excellent work of Derek, and as discussed on the `pdl-devel` mailing list, I believe this covers all of the changes required to transition to using GitHub for PDL development going forward.

I reproduce here my proposed list of needed actions:
- [x] ensure all the people who should have push access are on GH and are in the PDLPorters organisation
- [x] ensure all SF issues are present as GH issues
- [x] announce say a week in advance we will be switching the repo location
- [ ] CODE FREEZE as releases are going to be happening
- [ ] at the same time, dev-release new version with the updated: repo location, bugtracker location
- [ ] after that week, proper-release that version
- [ ] quick final check that GH and SF repos are in sync
- [ ] turn off Christian’s script – no more error emails!
- [ ] sweep up stragglers who should be in PDLPorters but aren't

I would suggest the intent is already clear, so I have marked some of these done. If everyone is happy with these changes, I would suggest the next stage is merge (which I will do), then Chris can announce code freeze, dev-release, then when he is happy, main-release.