### PR TITLE
Build and metadata fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,6 @@ before_install:
   - build-perl
   - perl -V
   - cpanm --quiet --notest ExtUtils::F77 Term::ReadLine::Gnu PGPLOT # do not need tests
-  - cpanm --quiet --notest Devel::CheckLib # specify this now because this is a CONFIGURE_REQUIRES for author-side
   - if [ "$AUTHOR_TESTING" == 1 ]; then cpanm --quiet --notest CPAN::Changes; fi # for author tests (AUTHOR_TESTING is set to true by default by init)
   - if [ "$EUMM_BLEAD" == 1 ]; then cpanm --quiet --notest --dev ExtUtils::MakeMaker; fi
   - build-dist

--- a/Basic/Core/Makefile.PL
+++ b/Basic/Core/Makefile.PL
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Devel::CheckLib;
+eval { require Devel::CheckLib; Devel::CheckLib->import; };
 use Config;
 use ExtUtils::MakeMaker;
 

--- a/IO/Browser/Makefile.PL
+++ b/IO/Browser/Makefile.PL
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use ExtUtils::MakeMaker;
 use File::Spec;
-use Devel::CheckLib;
+eval { require Devel::CheckLib; Devel::CheckLib->import; };
 
 my @pack = (["browser.pd", qw(Browser PDL::IO::Browser)]);
 

--- a/Lib/GIS/Proj/Makefile.PL
+++ b/Lib/GIS/Proj/Makefile.PL
@@ -18,8 +18,12 @@ if (defined $PDL::Config{$config_flag} && $PDL::Config{$config_flag}==0) {
   return;
 }
 
-require Alien::Proj4; # runtime not compile-time so return above will work
-my @inc = Alien::Proj4->default_inc;
+eval { require Alien::Proj4 }; # runtime not compile-time so return above will work
+my @inc = eval { Alien::Proj4->default_inc };
+if ($@) {
+  write_dummy_make("Will skip build of $package_name on this system");
+  return;
+}
 @inc = @{$PDL::Config{$config_incs}}
   if $PDL::Config{$config_incs} and @{$PDL::Config{$config_incs}};
 push @inc, qw(include);

--- a/Lib/GIS/Proj/Makefile.PL
+++ b/Lib/GIS/Proj/Makefile.PL
@@ -22,6 +22,7 @@ eval { require Alien::Proj4 }; # runtime not compile-time so return above will w
 my @inc = eval { Alien::Proj4->default_inc };
 if ($@) {
   write_dummy_make("Will skip build of $package_name on this system");
+  $PDL::Config{$config_flag}=0; # we know Proj4 doesn't work
   return;
 }
 @inc = @{$PDL::Config{$config_incs}}

--- a/Lib/Transform/Proj4/Makefile.PL
+++ b/Lib/Transform/Proj4/Makefile.PL
@@ -16,8 +16,12 @@ if (defined $PDL::Config{$config_flag} && $PDL::Config{$config_flag}==0) {
   return;
 }
 
-require Alien::Proj4; # runtime not compile-time so return above will work
-my @inc = Alien::Proj4->default_inc;
+eval { require Alien::Proj4 }; # runtime not compile-time so return above will work
+my @inc = eval { Alien::Proj4->default_inc };
+if ($@) {
+  write_dummy_make("Will skip build of $package_name on this system");
+  return;
+}
 @inc = @{$PDL::Config{$config_incs}}
   if $PDL::Config{$config_incs} and @{$PDL::Config{$config_incs}};
 push @inc, File::Spec->catdir((File::Spec->updir) x 2, qw(GIS Proj include));

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ use warnings;
 use Cwd;
 use lib Cwd::abs_path('inc');
 
-use Devel::CheckLib;
+eval { require Devel::CheckLib; Devel::CheckLib->import; };
 use 5.010_000;
 use ExtUtils::MakeMaker 6.56;  # for CONFIGURE_REQUIRES support
 use Config;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -476,7 +476,8 @@ my %makefile_hash = (
                        web => 'https://github.com/PDLPorters/pdl',
                     },
                  },
-                 no_index => { file => ['Doc/scantree.pl'] }
+                 no_index => { file => ['Doc/scantree.pl'] },
+                 x_IRC => 'irc://irc.perl.org/#pdl',
               },
               'MAN1PODS' => { 'Bugs.pod' => '$(INST_MAN1DIR)/PDL::Bugs.$(MAN1EXT)',
                               'perldl' => '$(INST_MAN1DIR)/perldl.$(MAN1EXT)',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -466,6 +466,7 @@ my %makefile_hash = (
 	      'EXE_FILES' => \@exe_files,
 	      'PM' => { @podpms }, #so that the script docs are picked up
               'META_MERGE' => {
+                 "meta-spec" => { version => 2 },
                  resources => {
                     homepage => 'http://pdl.perl.org/',
                     bugtracker  => 'https://github.com/PDLPorters/pdl/issues',


### PR DESCRIPTION
I was trying to fix the `t/ufunc.t` failure on `PDL_WITH_BADVAL=0` (see https://travis-ci.org/PDLPorters/pdl/jobs/366125051) but ran into these other problems first, including the long-standing #207 which I believe this fixes. There were also a couple of metadata problems which I believe this fixes, including that MetaCPAN doesn't see the repository.

When this is merged, it will rerun the CI and we might get a little more info on the failure, which is caused by a `SEGV` when running the `qsortveci` test. I can't currently reproduce it on my system. @devel-chm, any ideas why Jerry's change would cause that? Also, if we can't figure it out, what do you think about temporarily reverting his patch, getting 2.019 out with the GitHub change, then re-adding it with a view to fixing?