### PR TITLE
Devrel2 fixups

### DIFF
--- a/Known_problems
+++ b/Known_problems
@@ -69,11 +69,7 @@ The following issues have been reported with this version of PDL:
   again.  The problem has been reported as a Term::ReadLine::Perl bug.
 
 
-- The following bugs are outstanding at time of the PDL-2.018_01 release:
-
-  ===============================================
-  TODO: need refs to github bugs here, not sf.net
-  ===============================================
+- See https://github.com/PDLPorters/pdl/issues for a full list of known issues.
 
 
 For more information on these and other PDL issues, and for


### PR DESCRIPTION
This temporarily reverts Jerry's patch for MatrixOps. When this is merged to master, I will make a PR to add it back in. I can't right now since SF's repo is giving

> `fatal: remote error: access denied or repository not exported: /p/pdl/code`

yet again. @d-lamb I saw your excellent work on a second `sf_to_gh`, can you just push that straight to master? Then @devel-chm could you merge this as well, then make a second dev-release?