### PR TITLE
Fix documentation system

### DIFF
--- a/Doc/Doc.pm
+++ b/Doc/Doc.pm
@@ -640,7 +640,7 @@ sub checkregex {
   return "(?i)$regex" unless $regex =~ /^m[^a-z,A-Z,0-9]/;
   my $sep = substr($regex,1,1);
   substr($regex,0,2) = '';
-  $sep = '(?<!\\\\)\\'.$sep; # Avoid '\' before the separator 
+  $sep = '(?<!\\\\)\\'.$sep; # Avoid '\' before the separator
 
   my ($pattern,$mod) = split($sep,$regex,2);
   barf "unknown regex modifiers '$mod'" if $mod && $mod !~ /[imsx]+/;
@@ -891,7 +891,7 @@ sub add_module {
 	}
 	return if($hit);
     }
-    
+
     die "Unable to find a .pm or .pod file in \@INC for module $module\n";
 }
 

--- a/Doc/Doc.pm
+++ b/Doc/Doc.pm
@@ -165,7 +165,7 @@ An implementation of online docs for PDL.
 =head1 Using PDL documentation
 
 PDL::Doc's main use is in the "help" (synonym "?") and "apropos"
-(synonym "??") commands in the perldl shell.  PDL:Doc provides the
+(synonym "??") commands in the perldl shell.  PDL::Doc provides the
 infrastrucure to index and access PDL's documentation through these
 commands.  There is also an API for direct access to the documentation 
 database (see below).

--- a/Doc/Doc.pm
+++ b/Doc/Doc.pm
@@ -506,7 +506,7 @@ sub savedb {
         $val->{File} = File::Spec->abs2rel($fi, dirname($this->{Outfile})) ;
       }
       delete $val->{Dbfile}; # no need to store Dbfile
-      my $txt = "$name".chr(0)."$module".chr(0).join(chr(0),%$val);
+      my $txt = join(chr(0),$name,$module,%$val);
       print OUT pack("S",length($txt)).$txt;
     }
   }
@@ -704,7 +704,7 @@ sub scan {
     if (defined($val->{Module})){
 	$hash->{$key}->{$val->{Module}} = $val;
     } else {
-	print STDERR "no Module for $key in $file2\n";
+	warn "no Module for $key in $file2\n";
     }
 }
 

--- a/Doc/Doc.pm
+++ b/Doc/Doc.pm
@@ -823,7 +823,7 @@ sub getfuncdocs {
 #  $parser->select("\\(METHODS\\|OPERATORS\\|CONSTRUCTORS\\|FUNCTIONS\\|METHODS\\)/$func(\\(.*\\)*\\s*");
   foreach my $foo(qw/FUNCTIONS OPERATORS CONSTRUCTORS METHODS/) {
       seek $in,0,0;
-      $parser->select("$foo/$func(\\(.*\\))*\\s*");
+      $parser->select("$foo/(.*,\\s+)*$func(\\(.*\\))*(\\s*|,\\s+.*)");
       $parser->parse_from_filehandle($in,$out);
   }
 }

--- a/Doc/Doc.pm
+++ b/Doc/Doc.pm
@@ -472,11 +472,12 @@ sub ensuredb {
       my ($len) = unpack "S", $plen;
       read IN, $txt, $len;
       my (@a) =  split chr(0), $txt;
+      my $module = splice @a,1,1;
       push(@a, "") unless(@a % 2);  # Add null string at end if necessary -- solves bug with missing REF section.
       my ($sym, %hash) = @a;
      
       $hash{Dbfile} = $fi; # keep the origin pdldoc.db path
-      $this->{SYMS}->{$sym} = {%hash};
+      $this->{SYMS}->{$sym}->{$module} = {%hash};
     }
     close IN;
     push @{$this->{Scanned}}, $fi;
@@ -496,16 +497,18 @@ sub savedb {
   my $hash = $this->ensuredb();
   open OUT, ">$this->{Outfile}" or barf "can't write to symdb $this->{Outfile}";
   binmode OUT;
-  while (my ($key,$val) = each %$hash) {
-    next if 0 == scalar(%$val);
-    my $fi = $val->{File};
-    if (File::Spec->file_name_is_absolute($fi) && -f $fi) {
-      #store paths to *.pm files relative to pdldoc.db
-      $val->{File} = File::Spec->abs2rel($fi, dirname($this->{Outfile})) ;
+  while (my ($name,$mods_hash) = each %$hash) {
+    next if 0 == scalar(%$mods_hash);
+    while (my ($module,$val) = each %$mods_hash){
+      my $fi = $val->{File};
+      if (File::Spec->file_name_is_absolute($fi) && -f $fi) {
+        #store paths to *.pm files relative to pdldoc.db
+        $val->{File} = File::Spec->abs2rel($fi, dirname($this->{Outfile})) ;
+      }
+      delete $val->{Dbfile}; # no need to store Dbfile
+      my $txt = "$name".chr(0)."$module".chr(0).join(chr(0),%$val);
+      print OUT pack("S",length($txt)).$txt;
     }
-    delete $val->{Dbfile}; # no need to store Dbfile
-    my $txt = "$key".chr(0).join(chr(0),%$val);
-    print OUT pack("S",length($txt)).$txt;
   }
 }
 
@@ -514,30 +517,38 @@ sub savedb {
 
 Return the PDL symhash (e.g. for custom search operations)
 
-The symhash is a multiply nested hash with the following structure:
+The symhash is a multiply nested hash ref with the following structure:
 
  $symhash = {
      function_name => {
-             Module => 'module::name',
-             Sig    => 'signature string',
-             Bad    => 'bad documentation string',
-             ...
-         },
+             module::name => {
+                  Module => 'module::name',
+                  Sig    => 'signature string',
+                  Bad    => 'bad documentation string',
+                  ...
+                  },
+             },
      function_name => {
-             Module => 'module::name',
-             Sig    => 'signature string',
-             Bad    => 'bad documentation string',
-             ...
-         },
-     };
+             module::name => {
+                  Module => 'module::name',
+                  Sig    => 'signature string',
+                  Bad    => 'bad documentation string',
+                  ...
+                  },
+             },
+ }
 
-The possible keys for each function include:
+The three-layer structure is designed to allow the symhash (and the
+underlying database) to handle functions that have the same name but
+reside in different module namespaces.
+
+The possible keys for each function/module entry include:
 
  Module   - module name
  Sig      - signature
  Crossref - the function name for the documentation, if it has multiple
             names (ex: the documentation for zeros is under zeroes)
- Names    - a comma-separated string of the all the function's names
+ Names    - a comma-separated string of all the function's names
  Example  - example text (optional)
  Ref      - one-line reference string
  Opt      - options
@@ -575,11 +586,11 @@ that should be matched against the regex. Valid fields are
 If you wish to have your results sorted by function name, pass a true
 value for C<$sort>.
 
-The results will be returned as an array of pairs in the form
+The results will be returned as an array of triplets in the form
 
  @results = (
-  [funcname, {SYMHASH_ENTRY}],
-  [funcname, {SYMHASH_ENTRY}],
+  [funcname, module, {SYMHASH_ENTRY}],
+  [funcname, module, {SYMHASH_ENTRY}],
   ...
  );
 
@@ -600,16 +611,18 @@ sub search {
 
   $pattern = $this->checkregex($pattern);
 
-  while (my ($key,$val) = each %$hash) {
-    FIELD: for (@$fields) {
-      if ($_ eq 'Name' and $key =~ /$pattern/i
-          or defined $val->{$_} and $val->{$_} =~ /$pattern/i) {
-        $val = $hash->{$val->{Crossref}}
-          if defined $val->{Crossref} && defined $hash->{$val->{Crossref}};
-        push @match, [$key,$val];
-        last FIELD;
+  while (my ($name,$mods_hash) = each %$hash) {
+      while (my ($module,$val) = each %$mods_hash){
+	FIELD: for (@$fields) {
+	    if ($_ eq 'Name' and $name =~ /$pattern/i
+		or defined $val->{$_} and $val->{$_} =~ /$pattern/i) {
+		$val = $hash->{$val->{Crossref}}->{$module} #we're going to assume that any Crossref'd documentation is also in this module
+		if defined $val->{Crossref} && defined $hash->{$val->{Crossref}}->{$module};
+		push @match, [$name,$module,$val];
+		last FIELD;
+	    }
+	}
       }
-    }
   }
   @match = sort {$a->[0] cmp $b->[0]} @match if (@match && $sort);
   return @match;
@@ -687,13 +700,13 @@ sub scan {
     $n++;
 
     $val->{File} = $file2;
-    #the stored key is now 'PDL::SomeModule::funcname'
-    $key = $val->{Module} . "::$key";
-    #print "adding '$key'\n";
-    if (!defined($hash->{$key})){
-      $hash->{$key} = $val;
+    #set up the 3-layer hash/database structure: $hash->{funcname}->{PDL::SomeModule} = $val
+    if (defined($val->{Module})){
+	$hash->{$key}->{$val->{Module}} = $val;
+    } else {
+	print STDERR "no Module for $key in $file2\n";
     }
-  }
+}
 
   # KGB pass2 - scan for module name and function
   # alright I admit this is kludgy but it works
@@ -722,7 +735,7 @@ sub scan {
 	       ($does =~ /shell|script/i && $name =~ /^[a-z][a-z0-9]*$/) ? 'Script:' 
 	       : 'Manual:'
 	       : 'Module:');
-   $hash->{$name} = {Ref=>"$type $does",File=>$file2} if $name !~ /^\s*$/;
+   $hash->{$name}->{$name} = {Ref=>"$type $does",File=>$file2} if $name !~ /^\s*$/;
    return $n;
 }
 
@@ -765,16 +778,15 @@ extract the complete documentation about a function from its
 =cut
 
 sub funcdocs {
-  my ($this,$func,$fout) = @_;
+  my ($this,$func,$module,$fout) = @_;
   my $hash = $this->ensuredb;
   barf "unknown function '$func'" unless defined($hash->{$func});
-  my $file = $hash->{$func}->{File};
-  my $dbf = $hash->{$func}->{Dbfile};
+  barf "funcdocs now requires 3 arguments" if UNIVERSAL::isa($module,IO::File);
+  my $file = $hash->{$func}->{$module}->{File};
+  my $dbf = $hash->{$func}->{$module}->{Dbfile};
   if (!File::Spec->file_name_is_absolute($file) && $dbf) {
     $file = File::Spec->rel2abs($file, dirname($dbf)); 
   }
-  #In this file, don't search for 'PDL::SomeModule::funcname', just 'funcname'
-  $func =~ s/((\w+::)+)(\w+)$/$3/;
   funcdocs_fromfile($func,$file,$fout);
 }
 
@@ -901,31 +913,35 @@ own code.
          last DIRECTORY;
      }
  }
- 
+
  die ("Unable to find docs database!\n") unless $pdldoc;
- 
+
  # Print the reference line for zeroes:
- print $pdldoc->gethash->{zeroes}->{Ref};
- 
- # See which examples use zeroes
- $pdldoc->search('zeroes', 'Example', 1);
- 
+ print map{$_->{Ref}} values %{$pdldoc->gethash->{zeroes}};
+ # Or, if you remember that zeroes is in PDL::Core:
+ print $pdldoc->gethash->{zeroes}->{PDL::Core}->{Ref};
+
+ # Get info for all the functions whose examples use zeroes
+ my @entries = $pdldoc->search('zeroes','Example',1);
+
  # All the functions that use zeroes in their example:
- my @entries = $pdldoc->search('zeroes', 'Example', 1);
  print "Functions that use 'zeroes' in their examples include:\n";
  foreach my $entry (@entries) {
      # Unpack the entry
-     my ($func_name, $sym_hash) = @$entry;
+     my ($func_name, $module, $sym_hash) = @$entry;
      print "$func_name\n";
  }
- 
  print "\n";
- 
+
+ #Or, more concisely:
+ print join("\n",map{$_->[0]}@entries);
+
+
  # Let's look at the function 'mpdl'
  @entries = $pdldoc->search('mpdl', 'Name');
  # I know there's only one:
  my $entry = $entries[0];
- my ($func_name, $sym_hash) = @$entry;
+ my ($func_name, undef, $sym_hash) = @$entry;
  print "mpdl info:\n";
  foreach my $key (keys %$sym_hash) {
      # Unpack the entry
@@ -938,9 +954,8 @@ How can you tell if you've gotten a module for one of your entries?
 The Ref entry will begin with 'Module:' if it's a module. In code:
 
  # Prints:
- #  Module: fundamental PDL functionality
- my $sym_hash = $pdldoc->gethash;
- print $pdldoc->gethash->{'PDL::Core'}->{Ref}, "\n"
+ #  Module: fundamental PDL functionality and vectorization/threading
+ print $pdldoc->gethash->{'PDL::Core'}->{'PDL::Core'}->{Ref}, "\n"
 
 =head1 BUGS
 
@@ -949,11 +964,13 @@ discussions on the pdl-devel mailing list.
 
 =head1 AUTHOR
 
-Copyright 1997 Christian Soeller E<lt>c.soeller@auckland.ac.nzE<gt> 
+Copyright 1997 Christian Soeller E<lt>c.soeller@auckland.ac.nzE<gt>
 and Karl Glazebrook E<lt>kgb@aaoepp.aao.gov.auE<gt>
 
 Further contributions copyright 2010 David Mertens
 E<lt>dcmertens.perl@gmail.comE<gt>
+
+Documentation database restructuring 2019 Derek Lamb
 
 All rights reserved. There is no warranty. You are allowed
 to redistribute this software / documentation under certain

--- a/Doc/Doc.pm
+++ b/Doc/Doc.pm
@@ -683,12 +683,17 @@ sub scan {
   my $phash = $parser->{SYMHASH};
   my $n = 0;
   while (my ($key,$val) = each %$phash) {
-    #print "adding '$key'\n";
+
     $n++;
 
     $val->{File} = $file2;
-    $hash->{$key} = $val
+    #the stored key is now 'PDL::SomeModule::funcname'
+    $key = $val->{Module} . "::$key";
+    #print "adding '$key'\n";
+    if (!defined($hash->{$key})){
+      $hash->{$key} = $val;
     }
+  }
 
   # KGB pass2 - scan for module name and function
   # alright I admit this is kludgy but it works
@@ -768,6 +773,8 @@ sub funcdocs {
   if (!File::Spec->file_name_is_absolute($file) && $dbf) {
     $file = File::Spec->rel2abs($file, dirname($dbf)); 
   }
+  #In this file, don't search for 'PDL::SomeModule::funcname', just 'funcname'
+  $func =~ s/((\w+::)+)(\w+)$/$3/;
   funcdocs_fromfile($func,$file,$fout);
 }
 

--- a/Doc/Doc/Perldl.pm
+++ b/Doc/Doc/Perldl.pm
@@ -51,6 +51,7 @@ use PDL::Doc;
 use Pod::Select;
 use IO::File;
 use Pod::PlainText;
+use Term::ReadKey; #for GetTerminalSize
 
 $PDL::onlinedoc = undef;
 $PDL::onlinedoc = PDL::Doc->new(FindStdFile());
@@ -83,11 +84,7 @@ sub FindStdFile {
 # machines)
 #
 sub screen_width() {
-    return $ENV{COLUMNS}
-       || (($ENV{TERMCAP} =~ /co#(\d+)/) and $1)
-       || ($^O ne 'MSWin32' and $^O ne 'dos' and 
-	  ((`stty -a 2>/dev/null` =~ /columns\s*=?\s*(\d+)/) or (`stty -a 2>/dev/null` =~ /(\d+)\s+columns/)) and $1)
-       || 72;
+    return ( ( GetTerminalSize(\*STDOUT) )[0] );
 }
 
 sub printmatch {

--- a/Doc/Doc/Perldl.pm
+++ b/Doc/Doc/Perldl.pm
@@ -84,7 +84,7 @@ sub FindStdFile {
 # machines)
 #
 sub screen_width() {
-    return ( ( GetTerminalSize(\*STDOUT) )[0] );
+    return ( ( GetTerminalSize(\*STDOUT) )[0] // 72);
 }
 
 sub printmatch {

--- a/Doc/Doc/Perldl.pm
+++ b/Doc/Doc/Perldl.pm
@@ -22,7 +22,7 @@ Currently-implemented shorthands are
 
 =item * P:: (short for PDL::)
 
-=item * P::G (short for PDL::Graphics)
+=item * P::G:: (short for PDL::Graphics::)
 
 =back
 

--- a/Doc/Doc/Perldl.pm
+++ b/Doc/Doc/Perldl.pm
@@ -171,19 +171,15 @@ Regex search PDL documentation database
 =for example
 
  pdl> apropos 'pic'
- find_autodoc    P::Doc::Perldl  Internal helper routine that finds and returns documentation in the autoloader path,
-                                 if it exists. You feed in a topic and it searches for the file "${topic}.pdl". If
-                                 that exists, then the filename gets returned in a match structure appropriate for
-                                 the rest of finddoc.
- grabpic3d       P::G::TriD      Grab a 3D image from the screen.
- Pic             P::IO           Module: image I/O for PDL
- rim             P::IO::Pic      Read images in most formats, with improved RGB handling.
- rpic            P::IO::Pic      Read images in many formats with automatic format detection.
- rpiccan         P::IO::Pic      Test which image formats can be read/written
- wim             P::IO::Pic      Write a pdl to an image file with selected type (or using filename extensions)
- wmpeg           P::IO::Pic      Write an image sequence (a (3,x,y,n) byte pdl) as an animation.
- wpic            P::IO::Pic      Write images in many formats with automatic format selection.
- wpiccan         P::IO::Pic      Test which image formats can be read/written
+ PDL::IO::Pic    P::IO::Pic  Module: image I/O for PDL
+ grabpic3d       P::G::TriD  Grab a 3D image from the screen.
+ rim             P::IO::Pic  Read images in most formats, with improved RGB handling.
+ rpic            P::IO::Pic  Read images in many formats with automatic format detection.
+ rpiccan         P::IO::Pic  Test which image formats can be read/written
+ wim             P::IO::Pic  Write a pdl to an image file with selected type (or using filename extensions)
+ wmpeg           P::IO::Pic  Write an image sequence (a (3,x,y,n) byte pdl) as an animation.
+ wpic            P::IO::Pic  Write images in many formats with automatic format selection.
+ wpiccan         P::IO::Pic  Test which image formats can be read/written
 
 To find all the manuals that come with PDL, try
 
@@ -342,10 +338,12 @@ sub finddoc  {
 
 =for ref
 
-Internal helper routine that finds and returns documentation in the autoloader
-path, if it exists.  You feed in a topic and it searches for the file
-"${topic}.pdl".  If that exists, then the filename gets returned in a 
-match structure appropriate for the rest of finddoc.
+Internal routine that finds and returns documentation in the
+PDL::AutoLoader path, if it exists.
+
+You feed in a topic and it searches for the file "${topic}.pdl".  If
+that exists, then the filename gets returned in a match structure
+appropriate for the rest of finddoc.
 
 =cut
 

--- a/Doc/Doc/Perldl.pm
+++ b/Doc/Doc/Perldl.pm
@@ -77,7 +77,7 @@ sub screen_width() {
     return $ENV{COLUMNS}
        || (($ENV{TERMCAP} =~ /co#(\d+)/) and $1)
        || ($^O ne 'MSWin32' and $^O ne 'dos' and 
-	   (`stty -a 2>/dev/null` =~ /columns\s*=?\s*(\d+)/) and $1)
+	  ((`stty -a 2>/dev/null` =~ /columns\s*=?\s*(\d+)/) or (`stty -a 2>/dev/null` =~ /(\d+)\s+columns/)) and $1)
        || 72;
 }
 

--- a/Doc/Doc/Perldl.pm
+++ b/Doc/Doc/Perldl.pm
@@ -148,7 +148,7 @@ sub format_ref {
     $ref =~ s/\n*$//;
     $ref =~ s/\n/"\n                ".' 'x($max_mod_length+2)/eg;
     $ref =~ s/^\s*//;
-    if ( length($name) > 15 ) { 
+    if ( length($name) > 15 ) {
       push @text, sprintf "%s ...\n " . ' 'x15 . "%-*s  %s\n", $name, $max_mod_length, $module, $ref;
     } else {
       push @text, sprintf "%-15s %-*s  %s\n", $name, $max_mod_length, $module, $ref;
@@ -204,7 +204,7 @@ sub aproposover {
     my $func = shift;
     $func =~ s:\/:\\\/:g;
     search_docs("m/$func/",['Name','Ref','Module'],1);
-    
+
 }
 
 sub apropos  {
@@ -228,7 +228,7 @@ sub search_docs {
 
     @match = $PDL::onlinedoc->search($func,$types,$sortflag);
     push(@match,find_autodoc( $func, $exact ) );
-    
+
     @match;
 }
 

--- a/Doc/scantree.pl
+++ b/Doc/scantree.pl
@@ -67,7 +67,7 @@ EOPOD
 #print POD "=over ",$#mans+1,"\n\n";
 print POD "=over 4\n\n";
 for (@mans) {
-  my $ref = $_->[1]->{Ref};
+  my $ref = $_->[2]->{Ref};
   $ref =~ s/Manual:/L<$_->[0]|$_->[0]> -/;
 ##  print POD "=item L<$_->[0]>\n\n$ref\n\n";
 #  print POD "=item $_->[0]\n\n$ref\n\n";
@@ -85,7 +85,7 @@ EOPOD
 #print POD "=over ",$#mods+1,"\n\n";
 print POD "=over 4\n\n";
 for (@scripts) {
-  my $ref = $_->[1]->{Ref};
+  my $ref = $_->[2]->{Ref};
   $ref =~ s/Script:/L<$_->[0]|PDL::$_->[0]> -/;
 ##  print POD "=item L<$_->[0]>\n\n$ref\n\n";
 #  print POD "=item $_->[0]\n\n$ref\n\n";
@@ -103,7 +103,7 @@ EOPOD
 #print POD "=over ",$#mods+1,"\n\n";
 print POD "=over 4\n\n";
 for (@mods) {
-  my $ref = $_->[1]->{Ref};
+  my $ref = $_->[2]->{Ref};
   next unless $_->[0] =~ /^PDL/;
   if( $_->[0] eq 'PDL'){ # special case needed to find the main PDL.pm file.
 	  $ref =~ s/Module:/L<PDL::PDL|PDL::PDL> -/;

--- a/Doc/scantree.pl
+++ b/Doc/scantree.pl
@@ -130,4 +130,7 @@ EOPOD
 
 close POD;
 
-
+#add the newly-created PDL::Index to the doc database
+$onldc->scan($outindex,$opt_v) if (-s $outindex);
+$onldc->savedb();
+1;

--- a/Graphics/TriD/POGL/OpenGL.pm
+++ b/Graphics/TriD/POGL/OpenGL.pm
@@ -115,25 +115,41 @@ my (@winObjects) = ();
 #
 #use fields qw/Display Window Context Options GL_Vendor GL_Version GL_Renderer/;
 
-=head2 new($class,$options,[$window_type])
-
-Returns a new OpenGL object with attributes specified in the options
-field, and of the 3d window type, if specified.  These attributes are:
+=head2 new
 
 =for ref
 
-  x,y - the position of the upper left corner of the window (0,0)
-  width,height - the width and height of the window in pixels (500,500)
-  parent - the parent under which the new window should be opened (root)
-  mask - the user interface mask (StructureNotifyMask)
-  attributes - attributes to pass to glXChooseVisual
+Returns a new OpenGL object.
+
+=for usage
+
+  new($class,$options,[$window_type])
+
+  Attributes are specified in the $options field; the 3d $window_type is optionsl. The attributes are:
+
+=over
+
+=item x,y - the position of the upper left corner of the window (0,0)
+
+=item width,height - the width and height of the window in pixels (500,500)
+
+=item parent - the parent under which the new window should be opened (root)
+
+=item mask - the user interface mask (StructureNotifyMask)
+
+=item attributes - attributes to pass to glXChooseVisual
+
+=back
 
 Allowed 3d window types, case insensitive, are:
 
-=for ref
+=over
 
-  glut - use Perl OpenGL bindings and GLUT windows (no Tk)
-  x11  - use Perl OpenGL (POGL) bindings with X11 (disabled)
+=item glut - use Perl OpenGL bindings and GLUT windows (no Tk)
+
+=item x11  - use Perl OpenGL (POGL) bindings with X11 (disabled)
+
+=back
 
 =cut
 
@@ -318,9 +334,13 @@ sub XPending {
 }
 
 
-=head2 XResizeWindow(x,y)
+=head2 XResizeWindow
 
 OO interface to XResizeWindow
+
+=for usage
+
+  XResizeWindow(x,y)
 
 =cut
 

--- a/IO/GD/GD.pd
+++ b/IO/GD/GD.pd
@@ -310,9 +310,13 @@ EOC
 #
 pp_addpm(<<'ENDPM');
 
-=head2 write_png_best( $img(piddle), $lut(piddle), $filename )
+=head2 write_png_best
 
 Like write_png(), but it assumes the best PNG compression (9).
+
+=for example
+
+  write_png_best( $img(piddle), $lut(piddle), $filename )
 
 =cut
 
@@ -325,9 +329,13 @@ sub write_png_best
     return write_png_ex( $img, $lut, $filename, 9 );
 } # End of write_png_best()...
 
-=head2 write_true_png_best( $img(piddle), $filename )
+=head2 write_true_png_best
 
 Like write_true_png(), but it assumes the best PNG compression (9).
+
+=for example
+
+  write_true_png_best( $img(piddle), $filename )
 
 =cut
 
@@ -704,7 +712,7 @@ ENDCODE
 # Function to write Read PNG LUT Table into a piddle variable:
 pp_addpm(<<'EOPM');
 
-=head2 my $lut = read_png_lut( $filename )
+=head2 read_png_lut( $filename )
 
 Reads a color LUT from an already-existing palette PNG file.
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -412,7 +412,8 @@ my @prereq = (
 	   'Pod::Select'         => 0,         # version TBD for PDL::Doc
            'Scalar::Util'        => 0,
            'Storable'            => 1.03,      # for PDL::IO::Storable
-	   'Text::Balanced'      => 1.89,      # for PDL::NiceSlice
+           'Term::ReadKey'       => 2.34,      #for perldl shell
+           'Text::Balanced'      => 1.89,      # for PDL::NiceSlice
 	  );
 
 # add OpenGL version dependency for CPAN to follow


### PR DESCRIPTION
If this branch were merged into master, nothing would break and usability would be improved.  As is, this accomplishes:
- functions whose name duplicates the name of a function in a different module now show up in the documentation database;
- the 'apropos', 'usage', 'sig', and 'badinfo' documentation helper functions now work with the documentation database's different naming convention

What remains is to account for functions that share documentation.  For example, mzeroes, mones, & msequence in PDL::Matrix all have an entry in the database, but do not appear to have any actual documentation that makes it in.  So doing 'help mzeroes' results in a blank entry.  One must be careful that the change that fixes this does not result in extraneous info in the other cases: using 'help inner' as a comparison is advised.

I believe that properly changing the regexp in [getfuncdocs in Doc.pm](https://github.com/PDLPorters/pdl/blob/5b9846e754ac1241e05f8fb2a6cdd56d91d2e1f6/Doc/Doc.pm#L814l) would solve that remaining issue, but I have not figured out the correct incantation.

If merged, #222 and #28 should be able to be closed.