### PR TITLE
Fix tilde expansion tests for environments with non-existent $HOME.

### DIFF
--- a/t/fits.t
+++ b/t/fits.t
@@ -3,6 +3,8 @@
 
 use strict;
 
+use File::Basename;
+
 use PDL::LiteF;
 
 use PDL::Core ':Internal'; # For howbig()
@@ -319,9 +321,11 @@ SKIP:{
 ###############################
 # Check that tilde expansion works
 my $tildefile = cfile('~',"PDL-IO-FITS-test_$$.fits");
-lives_ok { sequence(3,5,2)->wfits($tildefile) } "wfits tilde expansion didn't fail";
-lives_ok { rfits($tildefile) } "rfits tilde expansion didn't fail";
+lives_ok { if(-w dirname($tildefile)) { sequence(3,5,2)->wfits($tildefile) } } "wfits tilde expansion didn't fail";
+lives_ok { if(-w dirname($tildefile)) { rfits($tildefile) } } "rfits tilde expansion didn't fail";
 $tildefile =~ s/^(~)/glob($1)/e; #use the same trick as in FITS.pm to resolve this filename.
-unlink($tildefile) or warn "Could not delete $tildefile: $!\n"; #clean up.
+if(-e $tildefile) {
+	unlink($tildefile) or warn "Could not delete $tildefile: $!\n"; #clean up.
+}
 
 1;

--- a/t/fits.t
+++ b/t/fits.t
@@ -34,8 +34,6 @@ END {
   unlink $file if defined $file and -e $file;
 }
 
-my $number_of_tests = 97;
-
 ################ Test rfits/wfits ########################
 
 my $t = long xvals(zeroes(11,20))-5;
@@ -334,10 +332,7 @@ if(-w dirname($tildefile)) {
 	$tildefile =~ s/^(~)/glob($1)/e; #use the same trick as in FITS.pm to resolve this filename.
 	unlink($tildefile) or warn "Could not delete $tildefile: $!\n"; #clean up.
 }
-else {
-	$number_of_tests -= 2;
-}
 
-done_testing($number_of_tests);
+done_testing();
 
 1;

--- a/t/fits.t
+++ b/t/fits.t
@@ -14,7 +14,7 @@ use PDL::Config;
 
 kill 'INT',$$  if $ENV{UNDER_DEBUGGER}; # Useful for debugging.
 
-use Test::More tests => 97;
+use Test::More;
 use Test::Exception;
 
 BEGIN {
@@ -33,6 +33,8 @@ my $file = cfile $tempd, "iotest$$";
 END {
   unlink $file if defined $file and -e $file;
 }
+
+my $number_of_tests = 97;
 
 ################ Test rfits/wfits ########################
 
@@ -320,12 +322,22 @@ SKIP:{
 
 ###############################
 # Check that tilde expansion works
+
 my $tildefile = cfile('~',"PDL-IO-FITS-test_$$.fits");
-lives_ok { if(-w dirname($tildefile)) { sequence(3,5,2)->wfits($tildefile) } } "wfits tilde expansion didn't fail";
-lives_ok { if(-w dirname($tildefile)) { rfits($tildefile) } } "rfits tilde expansion didn't fail";
-$tildefile =~ s/^(~)/glob($1)/e; #use the same trick as in FITS.pm to resolve this filename.
-if(-e $tildefile) {
+
+# Only read/write the tildefile if the directory is writable.
+# Some build environments, like the Debian pbuilder chroots, use a non-existent $HOME.
+# See: https://github.com/PDLPorters/pdl/issues/238
+if(-w dirname($tildefile)) {
+	lives_ok { sequence(3,5,2)->wfits($tildefile) } "wfits tilde expansion didn't fail";
+	lives_ok { rfits($tildefile) } "rfits tilde expansion didn't fail";
+	$tildefile =~ s/^(~)/glob($1)/e; #use the same trick as in FITS.pm to resolve this filename.
 	unlink($tildefile) or warn "Could not delete $tildefile: $!\n"; #clean up.
 }
+else {
+	$number_of_tests -= 2;
+}
+
+done_testing($number_of_tests);
 
 1;


### PR DESCRIPTION
As reported in #238 the Debian package build of PDL 2.019 failed because the build environment uses a non-existent `$HOME`.

The failure was fixed by only reading & writing the test file if the directory is writable.

Fixes: #238 
