### PR TITLE
Make functions in Types.pm visible to pdldoc.

### DIFF
--- a/Basic/Core/Types.pm.PL
+++ b/Basic/Core/Types.pm.PL
@@ -343,7 +343,7 @@ the L<type|PDL::Core/type> method.
 Skip to the end of this document to find out how to change
 the set of types supported by PDL.
 
-=head1 Support functions
+=head1 FUNCTIONS
 
 A number of functions are available for module writers
 to get/process type information. These are used in various
@@ -352,7 +352,15 @@ appropriate type loops, etc.
 
 =head2 typesrtkeys
 
-return array of keys of typehash sorted in order of type complexity
+=for ref
+
+Returns an array of keys of typehash sorted in order of type complexity
+
+=for example
+
+ pdl> @typelist = PDL::Types::typesrtkeys;
+ pdl> print @typelist;
+ PDL_B PDL_S PDL_US PDL_L PDL_IND PDL_LL PDL_F PDL_D
 
 =cut
 
@@ -363,7 +371,15 @@ sub typesrtkeys {
 
 =head2 ppdefs
 
-return array of pp symbols for all known types
+=for ref
+
+Returns an array of pp symbols for all known types
+
+=for example
+
+ pdl> @ppdefs = PDL::Types::ppdefs
+ pdl> print @ppdefs;
+ B S U L N Q F D
 
 =cut
 
@@ -373,8 +389,19 @@ sub ppdefs {
 
 =head2 typefld
 
-return specified field (C<$fld>) for specified type (C<$type>)
+=for ref
+
+Returns specified field (C<$fld>) for specified type (C<$type>)
 by querying type hash
+
+=for usage
+
+PDL::Types::typefld($type,$fld);
+
+=for example
+
+ pdl> print PDL::Types::typefld('PDL_IND',realctype)
+ long
 
 =cut
 
@@ -386,7 +413,7 @@ sub typefld {
   return $typehash{$type}->{$fld};
 }
 
-=head2 mapfld (in_value, in_key, out_key)
+=head2 mapfld
 
 Map a given source field to the corresponding target field by
 querying the type hash. This gives you a way to say, "Find the type


### PR DESCRIPTION
Because there was no '=head1 FUNCTIONS' the functions never got
indexed.  Also I added some other POD directives and examples.