### PR TITLE
Use Config{WITH_SLATEC} in slatec-polyfit-weight.t startup

### DIFF
--- a/t/slatec-polyfit-weight.t
+++ b/t/slatec-polyfit-weight.t
@@ -13,14 +13,18 @@ use warnings;
 ## <https://github.com/PDLPorters/pdl/issues/48>
 
 use PDL::LiteF;
+use PDL::Config;
+
 BEGIN {
-	eval {
+    unless ($PDL::Config{WITH_SLATEC} &&
+	    eval {
 		require PDL::Slatec;
 		PDL::Slatec->import();
 		1;
-	} or do {
-		plan skip_all => "PDL::Slatec not available";
-	}
+	    }
+	) {
+	plan skip_all => "PDL::Slatec not available";
+    }
 }
 
 plan tests => 3;


### PR DESCRIPTION
This makes the test planning consistent between the two slatec
test programs.