### PR TITLE
Fix borover and bandover when using bad values...

### DIFF
--- a/Basic/Ufunc/ufunc.pd
+++ b/Basic/Ufunc/ufunc.pd
@@ -266,9 +266,8 @@ foreach my $func ( sort keys %over ) {
 	   $def . '=' . $init . ';
             loop(n) %{ ' . $op . ' if (' . $check . ') break; %}
             $b() = tmp;',
-	   BadCode => 
-	   'char tmp = ' . $init . ';
-	    $GENERIC(b) gtmp = '. $init . ';
+	   BadCode =>
+	    $def . '=' . $init .';
             int flag = 0;
             loop(n) %{
                if ( $ISGOOD(a()) ) { ' . $op . ' flag = 1; if (' . $check . ') break; }


### PR DESCRIPTION
 ...on systems with only unsigned chars.

This fixes GitHub issue #248. A rogue 'char tmp' instead of a
'$GENERIC() tmp' in the BadCode section of borover, bandover (and
also zcover, andover, and orover) caused problems on Raspberry Pi's.