### PR TITLE
Make PDL::Contants able to export DEGRAD.

### DIFF
--- a/Basic/Constants.pm
+++ b/Basic/Constants.pm
@@ -5,10 +5,8 @@ PDL::Constants -- basic compile time constants for PDL
 =head1 DESCRIPTION
 
 This module is used to define compile time constant
-values for PDL.  It uses the constant module for
-simplicity and availability.  We'll need to sort
-out exactly which constants make sense but PI and
-E seem to be fundamental.
+values for PDL.  It uses Perl's L<constant> pragma for
+simplicity and availability.
 
 =head1 SYNOPSIS
 
@@ -24,11 +22,11 @@ $VERSION = eval $VERSION;
 
 require Exporter;
 @ISA = qw(Exporter);
-@EXPORT_OK = qw(PI E I J);  # symbols to export
+@EXPORT_OK = qw(PI DEGRAD E I J);  # symbols to export
 
 use PDL::Lite;
 use PDL::Complex qw(i);
-                           
+
 =head2 PI
 
 The ratio of a circle's circumference to its diameter
@@ -39,7 +37,7 @@ use constant PI    => 4 * atan2(1, 1);
 
 =head2 DEGRAD
 
-The The number of degrees of arc per radian (180/PI)
+The number of degrees of arc per radian (180/PI)
 
 =cut
 

--- a/t/constants.t
+++ b/t/constants.t
@@ -3,16 +3,17 @@
 # Simple tests for PDL::Constants
 #
 BEGIN {
-   use Test::More tests => 3;
+   use Test::More tests => 4;
 }
 
 BEGIN {
-   use_ok( 'PDL::Constants', qw(PI E) );
+   use_ok( 'PDL::Constants', qw(PI E DEGRAD) );
 }
 
 # just checks values, assumes constant part is ok
 ok( abs( PI - 3.14159265358979 ) < 0.0001, 'PI is defined');
 ok( abs( E  - 2.71828182845905 ) < 0.0001, 'E  is defined');
+ok( abs( DEGRAD - 57.295779513082321 ) < 0.0001, 'DEGRAD is defined');
 
 # need to add tests for imaginary units (TODO)
 


### PR DESCRIPTION
DEGRAD was not in EXPORT_OK, and had to be called like PDL::Constants::DEGRAD.