### PR TITLE
Range speedup2

### DIFF
--- a/Basic/Slices/slices.pd
+++ b/Basic/Slices/slices.pd
@@ -409,8 +409,9 @@ pp_addpm(<<'EOD-range');
 
 sub PDL::range {
   my($source,$ind,$sz,$bound) = @_;
-  my $index = PDL->pdl($ind);
 
+# Convert to indx type up front (also handled in rangeb if necessary)
+  my $index = (ref $ind && UNIVERSAL::isa($ind,'PDL') && $ind->type eq 'indx') ? $ind : indx($ind);
   my $size = defined($sz) ? PDL->pdl($sz) : undef;
 
 
@@ -783,7 +784,7 @@ switch(ind_pdl->datatype) {
    PDL->converttype(&ind_pdl,PDL_IND,1); /* convert in place. */
    break;
  case PDL_IND:
-   /* do nothing */
+   PDL->make_physical(ind_pdl);
    break;
 }
 
@@ -890,6 +891,7 @@ switch(ind_pdl->datatype) {
         PDL->converttype(&size_pdl,PDL_IND,1); /* convert in place. */
         break;
       case PDL_IND:
+        PDL->make_physical(size_pdl);
         break;
       }
 
@@ -1083,7 +1085,11 @@ EOD-RedoDims
           if(ck < 0 || ck >= $PARENT_P(dims[k])) {
             switch($COMP(boundary[k])) {
             case 0: /* no boundary breakage allowed */
-              barf("index out-of-bounds in range");
+	      {
+		char barfstr[1024];
+		sprintf(barfstr,"index out-of-bounds in range (index vector #%ld)",item);
+		barf(barfstr);
+	      }
               break;
             case 1: /* truncation */
               trunc = 1;


### PR DESCRIPTION
This has the same two commits that were on the original range-speedup branch, which had gone stale and was 400 commits behind master.  I messed up that branch with a rebase gone wrong (note: never start a 400-commit rebase at midnight), so just created this branch and cherry-picked the two commits of interest.

For reference, I ran the following code:
~~~~perl
use strict;
use warnings;
use PDL;
use PDL::NiceSlice;
use Benchmark;
my $im = sequence(1024,1024);
my $indx = random(2,3000)->mult(1023,0)->rint;
timethis (1E5,
	  sub {$im->range($indx,10,'t');}
    );
~~~~

Without these commits I get about 11000 iterations per second, and with the commits about twice that many:

~~~~pre
timethis 100000:  9 wallclock secs ( 9.10 usr +  0.01 sys =  9.11 CPU) @ 10976.95/s (n=100000)
timethis 100000:  5 wallclock secs ( 4.46 usr +  0.00 sys =  4.46 CPU) @ 22421.52/s (n=100000)
~~~~