### PR TITLE
Fix PDL::Lite

### DIFF
--- a/Basic/Lite.pm
+++ b/Basic/Lite.pm
@@ -31,11 +31,9 @@ Access to other functions is by method syntax, viz:
 
 =cut
 
-# Load the fundamental PDL packages, no imports
-# Because there are no imports, we do not need
-# the usual 'eval in the user's namespace' routine.
+package PDL::Lite;
 
-use PDL::Core '';
+use PDL::Core qw(pdl piddle barf null);
 use PDL::Ops '';
 use PDL::Primitive '';
 use PDL::Ufunc '';
@@ -45,7 +43,6 @@ use PDL::Bad '';
 use PDL::Version ;  # Doesn't export anything - no need for ''
 use PDL::Lvalue;
 
-package PDL::Lite;
 $VERSION = $PDL::Version::VERSION;
 
 @ISA = qw( PDL::Exporter );

--- a/Basic/Lite.pm
+++ b/Basic/Lite.pm
@@ -33,6 +33,9 @@ Access to other functions is by method syntax, viz:
 
 package PDL::Lite;
 
+use strict;
+use warnings;
+
 use PDL::Core qw(pdl piddle barf null);
 use PDL::Ops '';
 use PDL::Primitive '';
@@ -43,11 +46,11 @@ use PDL::Bad '';
 use PDL::Version ;  # Doesn't export anything - no need for ''
 use PDL::Lvalue;
 
-$VERSION = $PDL::Version::VERSION;
+our $VERSION = $PDL::Version::VERSION;
 
-@ISA = qw( PDL::Exporter );
+our @ISA = qw( PDL::Exporter );
 
-@EXPORT = qw( piddle pdl null barf ); # Only stuff always exported!
+our @EXPORT = qw( piddle pdl null barf ); # Only stuff always exported!
 our %EXPORT_TAGS = (
    Func     => [@EXPORT],
 );

--- a/t/lite_loads_twice.t
+++ b/t/lite_loads_twice.t
@@ -1,7 +1,7 @@
 #  Can PDL::Lite be loaded twice?
 #  The first import was interfering with the second.  
 
-use Test::More tests => 10;
+use Test::More tests => 11;
 
 {
     package mk1;
@@ -26,3 +26,6 @@ foreach my $name (qw /x barf pdl piddle null/) {
     ok (mk2->can($name), "Sub loaded: mk2::" . $name);
 }
 
+# now try calling one of those functions
+eval { my $x = mk1::pdl(0, 1) };
+is $@, '', 'the imported pdl function ACTUALLY WORKS';


### PR DESCRIPTION
Sadly, a22a11fb9b2e5527af94fbb3cc39745ef1215f55 actually caused `PDL::Lite` to correctly export functions `pdl` etc, that were no longer being imported. This broke, among other things, `Test::PDL`.

This PR fixes that, with a test to avoid in future.