### PR TITLE
Nat c2

### DIFF
--- a/Basic/Bad/bad.pd
+++ b/Basic/Bad/bad.pd
@@ -534,7 +534,7 @@ EOC
     # - is there a better way of checking for the condition since
     #   the current one needs to be changed whenever the types are changed
     #
-    $set_code = "" if $usenan and ($type->ppsym eq "F" or $type->ppsym eq "D");
+    $set_code = "" if $usenan and ($type->ppsym eq "F" or $type->ppsym eq "D" or $type->ppsym eq "C" or $type->ppsym eq "G");
 
     $str .=
 "

--- a/Basic/Complex/complex.pd
+++ b/Basic/Complex/complex.pd
@@ -393,6 +393,7 @@ pp_def 'i2C',
 pp_def 'Cr2p',
        Pars => 'r(m=2); float+ [o]p(m=2)',
        Inplace => 1,
+       GenericTypes=>['B','S','U','L','N','F','D'],
        Doc => 'convert complex numbers in rectangular form to polar (mod,arg) form. Works inplace',
        Code => q!
           $GENERIC() x = $r(m=>0);

--- a/Basic/Core/Core.pm
+++ b/Basic/Core/Core.pm
@@ -2746,7 +2746,7 @@ sub PDL::convert {
 
 =for ref
 
-byte|short|ushort|long|indx|longlong|float|double (shorthands to convert datatypes)
+byte|short|ushort|long|indx|longlong|float|double|cfloat|cdouble (shorthands to convert datatypes)
 
 =for usage
 

--- a/Basic/Core/Makefile.PL
+++ b/Basic/Core/Makefile.PL
@@ -220,8 +220,7 @@ pdlcore.c:: pdlcore.c.PL Types.pm\n"
 }
 };
 
-my $libs_string = "$pthread_library $malloclib";
-$libs_string =~ s/^ $//;
+my $libs_string = "$pthread_library $malloclib -lm";
 
 my @cfiles = qw(pdlcore pdlapi pdlhash pdlthread pdlconv pdlmagic pdlsections);
 my $cobj = join ' ', map qq{$_\$(OBJ_EXT)}, @cfiles;

--- a/Basic/Core/Types.pm.PL
+++ b/Basic/Core/Types.pm.PL
@@ -59,6 +59,9 @@ my @types = (
 	      usenan => 0,           # do we need NaN handling for this type?
 	      packtype => 'C*',      # the perl pack type
 	      defaultbadval => 'UCHAR_MAX',
+	      real=>1,
+	      integer=>1,
+	      unsigned=>1,
 	     },
 	     {
 	      identifier => 'S',
@@ -68,6 +71,9 @@ my @types = (
 	      usenan => 0,
 	      packtype => 's*',
 	      defaultbadval => 'SHRT_MIN',
+	      real=>1,
+	      integer=>1,
+	      unsigned=>0,
 	     },
 	     {
 	      identifier => 'US',
@@ -78,6 +84,9 @@ my @types = (
 	      usenan => 0,
 	      packtype => 'S*',
 	      defaultbadval => 'USHRT_MAX',
+	      real=>1,
+	      integer=>1,
+	      unsigned=>1,
 	     },
 	     {
 	      identifier => 'L',
@@ -87,6 +96,9 @@ my @types = (
 	      usenan => 0,
 	      packtype => 'l*',
 	      defaultbadval => 'INT_MIN',
+	      real=>1,
+	      integer=>1,
+	      unsigned=>0,
 	     },
 
 #
@@ -103,6 +115,9 @@ my @types = (
         usenan => 0,
         packtype => &packtypeof_PDL_Indx,
         defaultbadval => 'LONG_MIN',
+        real=>1,
+        integer=>1,
+        unsigned=>0,
        },
 #
 #
@@ -123,6 +138,9 @@ my @types = (
 	                             # on the other hand 2^63 should be the
                                      # value of of llong_max which we should be
                                      # able to compute at runtime ?!
+	real=>1,
+	integer=>1,
+	unsigned=>0,
       },
 
 # IMPORTANT:
@@ -138,6 +156,9 @@ my @types = (
 		  usenan => 1,
 		  packtype => 'f*',
 	          defaultbadval => '-FLT_MAX',
+	          real=>1,
+	          integer=>0,
+	          unsigned=>0,
 	      },
 	      {
 		  identifier => 'D',
@@ -147,6 +168,38 @@ my @types = (
 		  usenan => 1,
 		  packtype => 'd*',
 	          defaultbadval => '-DBL_MAX',
+	          real=>1,
+	          integer=>0,
+	          unsigned=>0,
+	      },
+	      {
+		  identifier => 'CF',
+		  onecharident => 'G',   # only needed if different from identifier
+		  pdlctype => 'PDL_CFloat',
+		  realctype => 'complex float',
+		  convertfunc => 'cfloat',
+		  ppforcetype => 'cfloat',
+		  usenan => 0,
+		  packtype => '(ff)*',
+	          defaultbadval => '(complex float)( -FLT_MAX/2)',
+	          real=>0,
+	          integer=>0,
+	          unsigned=>0,
+	      },
+	      {
+		  identifier => 'CD',
+		  onecharident => 'C',   # only needed if different from identifier
+		  pdlctype => 'PDL_CDouble',
+		  realctype => 'complex double',
+		  convertfunc => 'cdouble',
+		  ppforcetype => 'cdouble',
+		  usenan => 0,
+		  packtype => '(dd)*',
+	          defaultbadval => '(complex double)( -DBL_MAX/2)',
+	          #defaultbadval => '-DBL_MAX',
+	          real=>0,
+	          integer=>0,
+	          unsigned=>0,
 	      },
 	      );
 
@@ -174,6 +227,27 @@ sub gentypenames {
   my @types = @_;
   checktypehas 'identifier', @types;
   my @ret = map {"PDL_$_->{identifier}"} @types;
+  return wantarray ? @ret : $ret[0];
+}
+
+sub is_real {
+  my @types = @_;
+  checktypehas 'real', @types;
+  my @ret = map {"$_->{real}"} @types;
+  return wantarray ? @ret : $ret[0];
+}
+
+sub is_unsigned {
+  my @types = @_;
+  checktypehas 'unsigned', @types;
+  my @ret = map {"$_->{unsigned}"} @types;
+  return wantarray ? @ret : $ret[0];
+}
+
+sub is_int {
+  my @types = @_;
+  checktypehas 'integer', @types;
+  my @ret = map {"$_->{integer}"} @types;
   return wantarray ? @ret : $ret[0];
 }
 

--- a/Basic/Core/pdl.h.PL
+++ b/Basic/Core/pdl.h.PL
@@ -31,6 +31,8 @@ print OUT <<"!GROK!THIS!";
 #ifndef __PDL_H
 #define __PDL_H
 
+#include <complex.h>
+
 #define PDL_DEBUGGING 1
 
 #ifdef PDL_DEBUGGING
@@ -49,6 +51,8 @@ extern int pdl_debugging;
                 case PDL_LL:  outsv = newSViv( (IV)(inany.value.Q) ); break; \\
                 case PDL_F:   outsv = newSVnv( (NV)(inany.value.F) ); break; \\
                 case PDL_D:   outsv = newSVnv( (NV)(inany.value.D) ); break; \\
+                case PDL_CF:  outsv = newSV( 50 ); sv_setpvf(outsv, "%.9g+%.9gi", creal(inany.value.G),cimag(inany.value.G)); break; \\
+                case PDL_CD:  outsv = newSV( 50 ); sv_setpvf(outsv, "%.17g+%.17gi",creal(inany.value.C),cimag(inany.value.C)); break; \\
                 default:      outsv = &PL_sv_undef; \\
             } \\
         } while (0)
@@ -62,6 +66,8 @@ extern int pdl_debugging;
                 case PDL_LL:  outany.type = avtype; outany.value.Q = (PDL_LongLong)(inval); break; \\
                 case PDL_F:   outany.type = avtype; outany.value.F = (PDL_Float)(inval);    break; \\
                 case PDL_D:   outany.type = avtype; outany.value.D = (PDL_Double)(inval);   break; \\
+                case PDL_CF:  outany.type = avtype; outany.value.G = (PDL_CFloat)(inval);   break; \\
+                case PDL_CD:  outany.type = avtype; outany.value.C = (PDL_CDouble)(inval);   break; \\
                 default:      outany.type = -1;     outany.value.B = 0; \\
             } \\
         } while (0)
@@ -75,6 +81,8 @@ extern int pdl_debugging;
                 case PDL_LL:  outval = (ctype)(inany.value.Q); break; \\
                 case PDL_F:   outval = (ctype)(inany.value.F); break; \\
                 case PDL_D:   outval = (ctype)(inany.value.D); break; \\
+                case PDL_CF:  outval = (ctype)(inany.value.G); break; \\
+                case PDL_CD:  outval = (ctype)(inany.value.C); break; \\
                 default:      outval = 0; \\
             } \\
         } while (0)
@@ -109,6 +117,8 @@ static inline int _anyval_eq_anyval(PDL_Anyval x, PDL_Anyval y) {
                 case PDL_LL:  return ((PDL_LongLong)(x.value.B) == y.value.Q) ? 1 : 0;
                 case PDL_F:   return ((PDL_Float)(x.value.B)    == y.value.F) ? 1 : 0;
                 case PDL_D:   return ((PDL_Double)(x.value.B)   == y.value.D) ? 1 : 0;
+                case PDL_CF:  return ((PDL_CFloat)(x.value.B)   == y.value.G) ? 1 : 0;
+                case PDL_CD:  return ((PDL_CDouble)(x.value.B)  == y.value.C) ? 1 : 0;
                 default:      return 0;
             }
         case PDL_S:
@@ -121,6 +131,8 @@ static inline int _anyval_eq_anyval(PDL_Anyval x, PDL_Anyval y) {
                 case PDL_LL:  return ((PDL_LongLong)(x.value.S) == y.value.Q) ? 1 : 0;
                 case PDL_F:   return ((PDL_Float)(x.value.S)    == y.value.F) ? 1 : 0;
                 case PDL_D:   return ((PDL_Double)(x.value.S)   == y.value.D) ? 1 : 0;
+                case PDL_CF:  return ((PDL_CFloat)(x.value.S)   == y.value.G) ? 1 : 0;
+                case PDL_CD:  return ((PDL_CDouble)(x.value.S)  == y.value.C) ? 1 : 0;
                 default:      return 0;
             }
         case PDL_US:
@@ -133,6 +145,8 @@ static inline int _anyval_eq_anyval(PDL_Anyval x, PDL_Anyval y) {
                 case PDL_LL:  return ((PDL_LongLong)(x.value.U) == y.value.Q) ? 1 : 0;
                 case PDL_F:   return ((PDL_Float)(x.value.U)    == y.value.F) ? 1 : 0;
                 case PDL_D:   return ((PDL_Double)(x.value.U)   == y.value.D) ? 1 : 0;
+                case PDL_CF:  return ((PDL_CFloat)(x.value.U)   == y.value.G) ? 1 : 0;
+                case PDL_CD:  return ((PDL_CDouble)(x.value.U)  == y.value.C) ? 1 : 0;
                 default:      return 0;
             }
         case PDL_L:
@@ -145,6 +159,8 @@ static inline int _anyval_eq_anyval(PDL_Anyval x, PDL_Anyval y) {
                 case PDL_LL:  return ((PDL_LongLong)(x.value.L) == y.value.Q) ? 1 : 0;
                 case PDL_F:   return ((PDL_Float)(x.value.L)    == y.value.F) ? 1 : 0;
                 case PDL_D:   return ((PDL_Double)(x.value.L)   == y.value.D) ? 1 : 0;
+                case PDL_CF:  return ((PDL_CFloat)(x.value.L)   == y.value.G) ? 1 : 0;
+                case PDL_CD:  return ((PDL_CDouble)(x.value.L)  == y.value.C) ? 1 : 0;
                 default:      return 0;
             }
         case PDL_IND:
@@ -157,6 +173,8 @@ static inline int _anyval_eq_anyval(PDL_Anyval x, PDL_Anyval y) {
                 case PDL_LL:  return ((PDL_LongLong)(x.value.N) == y.value.Q) ? 1 : 0;
                 case PDL_F:   return ((PDL_Float)(x.value.N)    == y.value.F) ? 1 : 0;
                 case PDL_D:   return ((PDL_Double)(x.value.N)   == y.value.D) ? 1 : 0;
+                case PDL_CF:  return ((PDL_CFloat)(x.value.N)   == y.value.G) ? 1 : 0;
+                case PDL_CD:  return ((PDL_CDouble)(x.value.N)  == y.value.C) ? 1 : 0;
                 default:      return 0;
             }
         case PDL_LL:
@@ -169,6 +187,8 @@ static inline int _anyval_eq_anyval(PDL_Anyval x, PDL_Anyval y) {
                 case PDL_LL:  return (x.value.Q                 == y.value.Q) ? 1 : 0;
                 case PDL_F:   return ((PDL_Float)(x.value.Q)    == y.value.F) ? 1 : 0;
                 case PDL_D:   return ((PDL_Double)(x.value.Q)   == y.value.D) ? 1 : 0;
+                case PDL_CF:  return ((PDL_CFloat)(x.value.Q)   == y.value.G) ? 1 : 0;
+                case PDL_CD:  return ((PDL_CDouble)(x.value.Q)  == y.value.C) ? 1 : 0;
                 default:      return 0;
             }
         case PDL_F:
@@ -181,6 +201,8 @@ static inline int _anyval_eq_anyval(PDL_Anyval x, PDL_Anyval y) {
                 case PDL_LL:  return (x.value.F                 == (PDL_Float)(y.value.Q)) ? 1 : 0;
                 case PDL_F:   return (x.value.F                 == y.value.F) ? 1 : 0;
                 case PDL_D:   return ((PDL_Double)(x.value.F)   == y.value.D) ? 1 : 0;
+                case PDL_CF:  return ((PDL_CFloat)(x.value.F)   == y.value.G) ? 1 : 0;
+                case PDL_CD:  return ((PDL_CDouble)(x.value.F)  == y.value.C) ? 1 : 0;
                 default:      return 0;
             }
         case PDL_D:
@@ -193,6 +215,36 @@ static inline int _anyval_eq_anyval(PDL_Anyval x, PDL_Anyval y) {
                 case PDL_LL:  return (x.value.D                 == (PDL_Double)(y.value.Q)) ? 1 : 0;
                 case PDL_F:   return (x.value.D                 == (PDL_Double)(y.value.F)) ? 1 : 0;
                 case PDL_D:   return (x.value.D                 == y.value.D) ? 1 : 0;
+                case PDL_CF:  return ((PDL_CFloat)(x.value.D)   == y.value.G) ? 1 : 0;
+                case PDL_CD:  return ((PDL_CDouble)(x.value.D)  == y.value.C) ? 1 : 0;
+                default:      return 0;
+            }
+        case PDL_CF:
+            switch (y.type) {
+                case PDL_B:   return (x.value.C                 == y.value.B) ? 1 : 0;
+                case PDL_S:   return ((PDL_Short)(x.value.C)    == y.value.S) ? 1 : 0;
+                case PDL_US:  return ((PDL_Ushort)(x.value.C)   == y.value.U) ? 1 : 0;
+                case PDL_L:   return ((PDL_Long)(x.value.C)     == y.value.L) ? 1 : 0;
+                case PDL_IND: return ((PDL_Indx)(x.value.C)     == y.value.N) ? 1 : 0;
+                case PDL_LL:  return ((PDL_LongLong)(x.value.C) == y.value.Q) ? 1 : 0;
+                case PDL_F:   return ((PDL_Float)(x.value.C)    == y.value.F) ? 1 : 0;
+                case PDL_D:   return ((PDL_Double)(x.value.C)   == y.value.D) ? 1 : 0;
+                case PDL_CF:  return ((PDL_CFloat)(x.value.C)   == y.value.G) ? 1 : 0;
+                case PDL_CD:  return (x.value.C                 == y.value.C) ? 1 : 0;
+                default:      return 0;
+            }
+        case PDL_CD:
+            switch (y.type) {
+                case PDL_B:   return (x.value.C                 == y.value.B) ? 1 : 0;
+                case PDL_S:   return ((PDL_Short)(x.value.C)    == y.value.S) ? 1 : 0;
+                case PDL_US:  return ((PDL_Ushort)(x.value.C)   == y.value.U) ? 1 : 0;
+                case PDL_L:   return ((PDL_Long)(x.value.C)     == y.value.L) ? 1 : 0;
+                case PDL_IND: return ((PDL_Indx)(x.value.C)     == y.value.N) ? 1 : 0;
+                case PDL_LL:  return ((PDL_LongLong)(x.value.C) == y.value.Q) ? 1 : 0;
+                case PDL_F:   return ((PDL_Float)(x.value.C)    == y.value.F) ? 1 : 0;
+                case PDL_D:   return ((PDL_Double)(x.value.C)   == y.value.D) ? 1 : 0;
+                case PDL_CF:  return ((PDL_CDouble)(x.value.B)  == y.value.G) ? 1 : 0;
+                case PDL_CD:  return (x.value.C                 == y.value.C) ? 1 : 0;
                 default:      return 0;
             }
         default:

--- a/Basic/Core/pdlcore.h.PL
+++ b/Basic/Core/pdlcore.h.PL
@@ -25,6 +25,7 @@ use vars qw( %PDL_DATATYPES );
 # version 10 for 64bit index support (PDL index datatype)
 # version 11 for core cleanup (proto-PDL-3)
 # version 12 for PDL_Anyval union data type (full 64bit support)
+# version 13 for complex data types (native complex support)
 use vars qw( $pdl_core_version );
 $pdl_core_version = 12;
 

--- a/Basic/Core/pdlsimple.h.PL
+++ b/Basic/Core/pdlsimple.h.PL
@@ -30,6 +30,7 @@ print "Extracting $file (with variable substitutions)\n";
 
 print OUT <<"!GROK!THIS!";
 
+#include <complex.h>
 #ifndef __PDL_H
 
 /* These are kept automaticallu in sync with pdl.h during perl build */

--- a/Basic/Gen/PP/PDLCode.pm
+++ b/Basic/Gen/PP/PDLCode.pm
@@ -631,6 +631,7 @@ my %set_nan =
     (
      float  => 'PDL->bvals.Float',  PDL_Float  => 'PDL->bvals.Float',
      double => 'PDL->bvals.Double', PDL_Double => 'PDL->bvals.Double',
+     cdouble => 'PDL->bvals.CDouble', PDL_CDouble => 'PDL->bvals.CDouble',
      );
 
 sub use_nan ($) {

--- a/Basic/Math/math.pd
+++ b/Basic/Math/math.pd
@@ -44,7 +44,7 @@ sub doco {
 }
 
 doco (qw/acos asin atan tan/,
-'The usual trigonometric function.');
+'The usual trigonometric function. Note that when input is a perl scalar and the real-value based function would return Inf or NaN, it now returns a cdouble.');
 
 doco (qw/cosh sinh tanh acosh asinh atanh/,
 'The standard hyperbolic function.');
@@ -157,7 +157,7 @@ pp_addhdr('
 
 # Standard `-lm'
 my (@ufuncs1) = qw(acos asin atan cosh sinh tan tanh); # F,D only
-my (@ufuncs1g) = qw(ceil floor rint); # Any type
+my (@ufuncs1g) = qw(ceil floor rint); # Any real type
 
 # Note:
 #  ops.pd has a power() function that does the same thing
@@ -172,22 +172,37 @@ my (@besufuncs) = qw(j0 j1 y0 y1); # "
 my (@besbifuncs) = qw(jn yn); # "
 # Need igamma, ibeta, and a fall-back implementation of the above
 
-sub code_ufunc    { return '$b() = ' . $_[0] . '($a());'; }
+sub code_ufunc    { return '
+	types(G) %{ $b() = c' . $_[0] . 'f($a()); %}
+	types(C) %{ $b() = c' . $_[0] . '($a()); %}
+	types(BSULNFD) %{ $b() = ' . $_[0] . '($a()); %}
+	'; }
 sub badcode_ufunc {
     my $name = $_[0];
-    return 'if ( $ISBAD(a()) ) { $SETBAD(b()); } else { $b() = ' . $name . '($a()); }';
+    return 'if ( $ISBAD(a()) ) { $SETBAD(b()); } else {
+	types(G) %{ $b() = c' . $_[0] . 'f($a()); %}
+	types(C) %{ $b() = c' . $_[0] . '($a()); %}
+	types(BSULNFD) %{ $b() = ' . $_[0] . '($a()); %}
+	 }';
 }
 
 sub code_bifunc {
     my $name = $_[0]; my $x = $_[1] || 'a'; my $y = $_[2] || 'b';
     my $c = $_[3] || 'c';
-    return "\$$c() = $name(\$$x(),\$$y());";
+    return (
+	"types(BSULNFD) %{ \$$c() = $name(\$$x(),\$$y()); %} "
+	."types(C) %{ \$$c() = c$name(\$$x(),\$$y()); %} "
+	."types(G) %{ \$$c() = c".$name."f(\$$x(),\$$y()); %} "
+	."");
 }
 sub badcode_bifunc {
     my $name = $_[0]; my $x = $_[1] || 'a'; my $y = $_[2] || 'b';
     my $c = $_[3] || 'c';
     return 'if ( $ISBAD('.$x.'()) || $ISBAD('.$y.'()) ) { $SETBAD('.$c.'()); } else { ' .
-	"\$$c() = $name(\$$x(),\$$y()); }";
+	"types(BSULNFD) %{ \$$c() = $name(\$$x(),\$$y()); %} "
+	."types(C) %{ \$$c() = c$name(\$$x(),\$$y()); %} "
+	."types(G) %{ \$$c() = c${name}f(\$$x(),\$$y()); %} "
+	."}";
 }
 
 sub inplace_doc {
@@ -200,7 +215,7 @@ foreach $func (@ufuncs1) {
     pp_def($func,
 	   HandleBad => 1,
 	   NoBadifNaN => 1,
-	   GenericTypes => ['F','D'],
+	   GenericTypes => ['F','D','G','C'],
 	   Pars => 'a(); [o]b();',
 	   Inplace => 1,
 	   Doc => inplace_doc( $func ),
@@ -208,10 +223,12 @@ foreach $func (@ufuncs1) {
 	   BadCode => badcode_ufunc($func),
 	   );
 }
-
+my $R = ['B','S','U','L','N','F','D']; # should be using code from Types.pm to set up.
+# real types
 foreach $func (@ufuncs1g) {
     pp_def($func,
 	   HandleBad => 1,
+	   GenericTypes=>$R,
 	   NoBadifNaN => 1,
 	   Pars => 'a(); [o]b();',
 	   Inplace => 1,
@@ -278,6 +295,7 @@ foreach $func (@besbifuncs) {
 if ($^O !~ /win32/i) {
     pp_def("lgamma",
 	   HandleBad => 1,
+	   GenericTypes=>$R,
 	   Pars => 'a(); [o]b(); int[o]s()',
 	   Doc => $doco{"lgamma"},
 	   Code =>
@@ -298,6 +316,7 @@ if ($^O !~ /win32/i) {
 elsif ($Config{cc} =~ /\bgcc/i) {
     pp_def("lgamma",
 	   HandleBad => 1,
+	   GenericTypes=>$R,
 	   Pars => 'a(); [o]b(); int[o]s()',
 	   Doc => $doco{"lgamma"},
 	   Code =>
@@ -384,7 +403,7 @@ pp_def(
        "ndtri",
        HandleBad => 1,
        NoBadifNaN => 1,
-       GenericTypes => ['F','D'],
+       GenericTypes => ['F','D','G','C'],
        Pars => 'a(); [o]b()',
        Inplace => 1,
        Doc => inplace_doc( "ndtri" ),

--- a/Basic/Ops/ops.pd
+++ b/Basic/Ops/ops.pd
@@ -41,6 +41,7 @@ EOPM
 
 pp_addhdr('
 #include <math.h>
+#include <complex.h>
 
 /* MOD requires hackage to map properly into the positive-definite numbers. */
 /* Note that this code causes some warning messages in the compile, because */
@@ -61,6 +62,7 @@ pp_addhdr('
 #define BU_MOD(X,N)(((N) == 0)   ?    0   :   ( (X)-(N)*((int)((X)/(N))) ))
 #define SPACE(A,B)   ( ((A)<(B)) ? -1 : ((A)!=(B)) )
 #define ABS(A)       ( (A)>=0 ? (A) : -(A) )
+#define cABS(A)       ( sqrt(creal(A)*creal(A)+cimag(A)*cimag(A))  )
 #define NOTHING
 ');
 
@@ -79,7 +81,6 @@ sub biop {
     my ($name,$op,$swap,$doc,%extra) = @_;
     my $optxt = protect_chars ref $op eq 'ARRAY' ? $op->[1] : $op;
     $op = $op->[0] if ref $op eq 'ARRAY';
-
     if ($swap) {
 	$extra{HdrCode} = << 'EOH';
   pdl *tmp;
@@ -100,8 +101,24 @@ EOH
 	#      See also `ufunc()`.
 	delete $extra{Exception};
     }
+    if( exists $extra{Comparison} && 0) {
+	$pmcode= qq/
+		sub $name {
+			my \$x=shift;
+			my \$y=shift;
+			my \$ret=shift;
+			if (\$r && ( \$x->type eq 'cdouble' || \$y->type eq 'cdouble')) {
+				barf $op.' not defined for complex numbers!\n';
+			} else {
+				\$ret=&PDL::_${op}_int(\$x,\$y);
+			}
+			\$ret;
+		}
+	/,
+	}
     if( exists $extra{Comparison} && $PDL::Config{WITH_BADVAL} ) {
 	# *append* to header
+	# I am not sure if this should be changed to complex double?
 	$extra{HdrCode} .= <<'EOH';
            {
              double bad_a, bad_b;
@@ -115,6 +132,7 @@ EOH
     }
 
     pp_def($name,
+	   PMCode => $pmcode,
 	   Pars => 'a(); b(); [o]c();',
 	   OtherPars => 'int swap',
 	   HandleBad => 1,
@@ -186,6 +204,12 @@ EOH
     my $badcodestr;
     if ($extra{unsigned}){
     $codestr = << "ENDCODE";
+  types(C) %{
+  \$c() = c$func}(\$a(),\$b());
+  %}
+  types(G) %{
+  \$c() = c${func}f(\$a(),\$b());
+  %}
   types(BU) %{
   \$c() = BU_$func(\$a(),\$b());
   %}
@@ -271,11 +295,29 @@ sub ufunc {
 	   NoBadifNaN => 1,
 	   Inplace => 1,
 	   Code => pp_line_numbers(__LINE__,
-	   "\$b() = $func(\$a());"),
+	   "
+		    types(G) %{
+			    \$b() = c${func}f(\$a());
+		    %}
+		    types(C) %{
+			    \$b() = c$func(\$a());
+		    %}
+		    types(BUSLNQFD) %{
+			    \$b() = $func(\$a());
+		    %}
+	   "),
 	   BadCode =>
-	   pp_line_numbers(__LINE__, 'if ( ' . $badcode . ' )
-	      $SETBAD(b());
-	   else' . "\n  \$b() = $func(\$a());\n"),
+		    pp_line_numbers(__LINE__, 'if ( ' . $badcode . ' )
+		    $SETBAD(b());
+		    else' . "\n types(G) %{
+			    \$b() = c${func}f(\$a());
+		    %}
+		    types(C) %{
+			    \$b() = c$func(\$a());
+		    %}
+		    types(BUSLNQFD) %{
+		     \$b() = $func(\$a());
+		    %}\n"),
 	   %extra,
 	   Doc => << "EOD");
 =for ref
@@ -328,10 +370,14 @@ biop('divide','/',1,'divide two piddles', Exception => '$b() == 0' );
 
 ## comparison ops
 # need swapping
-biop('gt','>',1,'the binary E<gt> (greater than) operation', Comparison => 1 );
-biop('lt','<',1,'the binary E<lt> (less than) operation', Comparison => 1 );
-biop('le','<=',1,'the binary E<lt>= (less equal) operation', Comparison => 1 );
-biop('ge','>=',1,'the binary E<gt>= (greater equal) operation', Comparison => 1 );
+my $R = [B,U,S,L,N,Q,F,D]; # real types here
+my $Rs = join '',@$R;
+my $C = [C,G];
+# not defined for complex numbers
+biop('gt','>',1,'the binary E<gt> (greater than) operation', Comparison => 1, GenericTypes=>$R );
+biop('lt','<',1,'the binary E<lt> (less than) operation', Comparison => 1,GenericTypes=>$R );
+biop('le','<=',1,'the binary E<lt>= (less equal) operation', Comparison => 1,GenericTypes=>$R );
+biop('ge','>=',1,'the binary E<gt>= (greater equal) operation', Comparison => 1,GenericTypes=>$R );
 # no swap required but set anyway fixing sf bug #391
 biop('eq','==',1,'binary I<equal to> operation (C<==>)', Comparison => 1 );
 biop('ne','!=',1,'binary I<not equal to> operation (C<!=>)', Comparison => 1 );
@@ -352,20 +398,18 @@ biop('xor','^',1,'binary I<exclusive or> of two piddles',GenericTypes => $T,
 ufunc('bitnot','~','unary bit negation',GenericTypes => $T);
 
 # some standard binary functions
-bifunc('power',['pow','op**'],1,'raise piddle C<$a> to the power C<$b>',GenericTypes => [D]);
-bifunc('atan2','atan2',1,'elementwise C<atan2> of two piddles',GenericTypes => [D]);
-bifunc('modulo',['MOD','op%'],1,'elementwise C<modulo> operation',unsigned=>1);
-bifunc('spaceship',['SPACE','op<=>'],1,'elementwise "<=>" operation');
+bifunc('power',['pow','op**'],1,'raise piddle C<$a> to the power C<$b>',GenericTypes => [C,G,D]);
+bifunc('atan2','atan2',1,'elementwise C<atan2> of two piddles',GenericTypes => [D,F]);
+bifunc('modulo',['MOD','op%'],1,'elementwise C<modulo> operation',unsigned=>1,GenericTypes=>$R);
+bifunc('spaceship',['SPACE','op<=>'],1,'elementwise "<=>" operation', ,GenericTypes=>$R);
 
 # some standard unary functions
-ufunc('sqrt','sqrt','elementwise square root', Exception => '$a() < 0' );
-ufunc('abs',['ABS','abs'],'elementwise absolute value',GenericTypes => [D,F,S,L]);
+ufunc('sqrt','sqrt','elementwise square root',); # Exception => '$a() < 0' ,GenericTypes=>$R );
 ufunc('sin','sin','the sin function');
 ufunc('cos','cos','the cos function');
-ufunc('not','!','the elementwise I<not> operation');
-ufunc('exp','exp','the exponential function',GenericTypes => [D]);
-ufunc('log','log','the natural logarithm',GenericTypes => [D],
-      Exception => '$a() <= 0' );
+ufunc('not','!','the elementwise I<not> operation',GenericTypes=>$R );
+ufunc('exp','exp','the exponential function',GenericTypes => [D,C]);
+ufunc('log','log','the natural logarithm',GenericTypes => [D,C], Exception => '$a() <= 0' );
 
 pp_export_nothing();
 
@@ -429,6 +473,80 @@ This is unnecessary if $pdl->badflag is known to be 1 before the slice is perfor
 See http://pdl.perl.org/PDLdocs/BadValues.html#dataflow_of_the_badflag for details.'
 ); # pp_def assgn
 
+# special functions for complex data types that somehow don't work well with
+# the ufunc/bifunc logic
+
+pp_def(
+	'carg',
+	   HandleBad => 1,
+	   NoBadifNaN => 1,
+	 GenericTypes=>$C,
+	Pars=>'a(); double [o] b()',
+	Code=>'$b()=carg($a());',
+	BadCode => '
+		if ($ISBAD(a()) ) { $SETBAD(b()); } else { $b() = carg($a()); }
+		',
+	Doc=>'Returns the polar angle of a complex number. ' ,
+); # pp_def carg
+
+pp_def('conj',
+	   HandleBad => 1,
+	   NoBadifNaN => 1,
+	GenericTypes=>$C,
+	Doc=>'complex conjugate.',
+	Pars=>'a(); [o]b();',
+	Code => '$b()=conj($a());',
+	BadCode => '
+	       if ( $ISBAD(a())  )
+	           $SETBAD(b());
+	       else
+	           $b() = conj($a());
+	   ',
+);
+
+pp_def(
+	'creal',
+	   HandleBad => 1,
+	   NoBadifNaN => 1,
+	 GenericTypes=>$C,
+	Pars=>'a(); double [o] b()',
+	Code=>'$b()=creal($a());',
+	BadCode => q{
+	       if ( $ISBAD(a())  )
+	           $SETBAD(b());
+	       else
+	           $b() = creal($a());
+	   },
+	Doc=>'Returns the real part of a complex number. ' ,
+); # pp_def creal
+
+
+pp_def(
+	'cimag',
+	   HandleBad => 1,
+	   NoBadifNaN => 1,
+	 GenericTypes=>$C,
+	Pars=>'a(); double [o]b()',
+	Code=>'$b()=cimag($a());',
+	BadCode => q{
+	       if ( $ISBAD(a())  )
+	           $SETBAD(b());
+	       else
+	           $b() = cimag($a());
+	   },
+Doc=>'Returns the imaginary part of a complex number. ' ,
+); # pp_def cimag
+
+pp_def(
+	'ci',
+	   HandleBad => 1,
+	   NoBadifNaN => 1,
+	 GenericTypes=>$C,
+	Pars=>'cdouble [o]b();',
+	Code=>'$b()=0+1I;',
+	Doc=>'Returns the complex number 0 + 1i.' ,
+); # pp_def ci
+
 pp_def('ipow',
    Doc => qq{
 =for ref
@@ -478,8 +596,52 @@ Algorithm from L<Wikipedia|http://en.wikipedia.org/wiki/Exponentiation_by_squari
    })
 );
 
-
 #pp_export_nothing();
 
-pp_done();
+pp_def ( '_rabs',
+	GenericTypes=>[D,F,L,S],
+	Pars=>'a(); [o]b()',
+	HandleBad => 1,
+	NoBadifNaN => 1,
+	    Inplace => 1,
+	BadCode => '
+	       if ( $ISBAD(a()) )
+	           $SETBAD(b());
+	       else
+		$b()=ABS ($a()) ; ',
+	Code=>'$b()=ABS ($a()) ; ',
+	Doc=>'Returns the absolute value of a number. ' ,
+	PMFunc=>'',
+);
+pp_def(
+	'_cabs',
+	 GenericTypes=>$C,
+	 HandleBad => 1,
+	 NoBadifNaN => 1,
+	Pars=>'a(); double [o] b()',
+	BadCode => q{
+	       if ( $ISBAD(a()) )
+	           $SETBAD(b());
+	       else
+		$b()=cabs ($a()) ; },
+	Code=>'$b()=cabs($a());',
+	Doc=>'Returns the absolute (length) of a complex number. ' ,
+	PMFunc=>'',
+); # pp_def cabs
 
+pp_addpm(<<'EOPM');
+
+sub PDL::abs {
+	my $x=shift;
+	my $ret;
+	if ($x->type eq 'cdouble' or $x->type eq 'cfloat') {
+		$ret=PDL::_cabs($x);
+	} else {
+		$ret=PDL::_rabs($x);
+	}
+	$ret;
+}
+
+EOPM
+
+pp_done();

--- a/Basic/Primitive/primitive.pd
+++ b/Basic/Primitive/primitive.pd
@@ -1143,7 +1143,7 @@ clip (threshold) C<$a> by C<$b> (C<$b> is upper bound)
 clip (threshold) C<$a> by C<$b> (C<$b> is lower bound)
 
 =cut
-
+my $R=['B','S','U','L','N','F','D'];
 for my $opt (
 	     ['hclip','>'],
 	     ['lclip','<']
@@ -1153,6 +1153,7 @@ for my $opt (
     pp_def(
 	   $name,
 	   HandleBad => 1,
+	   GenericTypes => $R,
 	   Pars => 'a(); b(); [o] c()',
 	   Code =>
 	   '$c() = ($a() '.$op.' $b()) ? $b() : $a();',
@@ -1215,6 +1216,8 @@ EOD
 pp_def(
 	'clip',
 	HandleBad => 1,
+	GenericTypes => $R,
+
 	Pars => 'a(); l(); h(); [o] c()',
 	Code =>
 	'$c() = ( $a() > $h() )   ?   $h()   :  ( $a() < $l()   ?   $l()   :   $a()   );',
@@ -1341,6 +1344,7 @@ have its bad flag set if the output contains any bad data.
 
 pp_def('statsover',
 	HandleBad => 1,
+	GenericTypes => $R,
 	Pars => 'a(n); w(n); float+ [o]avg(); float+ [o]prms(); int+ [o]median(); int+ [o]min(); int+ [o]max(); float+ [o]adev(); float+ [o]rms()',
 	Code =>
 	'$GENERIC(avg) tmp = 0;

--- a/Basic/Ufunc/ufunc.pd
+++ b/Basic/Ufunc/ufunc.pd
@@ -108,6 +108,11 @@ EOD
 
 } # sub: cumuprojectdocs()
 
+# type classes to pass to GenericTypes. Should use the new attributes in Types.pm.
+my $R=[qw/B S U L Q N F D/];
+my $INT=[qw/B S U L Q N /];
+my $C=[qw/C G/];
+
 # it's a bit unclear what to do with the comparison operators,
 # since the return value could be bad because all elements are bad,
 # which needs checking for since the bad value could evaluate to 
@@ -155,7 +160,29 @@ foreach my $func ( sort keys %over ) {
 	   Doc => projectdocs( $name, $func, '' ),
 	   );
 
-    # as above, but in double precision
+    # as above, but in complex double precision
+    pp_def(
+	   "c$func",
+	   HandleBad => 1,
+	   GenericTypes=>$C,
+	   Pars => 'a(n); cdouble [o]b();',
+	   Code =>
+	   'complex double tmp = ' . $init . ';
+	    loop(n) %{ tmp ' . $op . ' $a(); %}
+	    $b() = tmp;',
+	   BadCode =>
+	   'complex double tmp = ' . $init . ';
+            int flag = 0;
+	    loop(n) %{
+               if ( $ISGOOD(a()) ) { tmp ' . $op . ' $a(); flag = 1; }
+            %}
+            if ( flag ) { $b() = tmp; }
+            else        { $SETBAD(b()); }',
+	   Doc => projectdocs( $name, "d$func",
+"Unlike L<$func|/$func>, the calculations are performed in complex double\n" .
+"precision." ),
+	   );
+
     pp_def(
 	   "d$func",
 	   HandleBad => 1,
@@ -225,6 +252,32 @@ foreach my $func ( sort keys %over ) {
 "precision." ),
 	   );
 
+    # as above but in complex double precision
+=for
+    pp_def(
+	   "c$cfunc",
+	   HandleBad => 1,
+	   Pars => 'a(n); cdouble [o]b(n);',
+	   Code =>
+           'complex double tmp = ' . $init . ';
+	    loop(n) %{
+               tmp ' . $op . ' $a();
+	       $b() = tmp;
+	    %}',
+	   BadCode =>
+	   'complex double tmp = ' . $init . ';
+	    loop(n) %{
+               if ( $ISBAD(a()) ) { $SETBAD(b()); }
+               else {
+                  tmp ' . $op . ' $a();
+	          $b() = tmp;
+               }
+	    %}',
+	   Doc => cumuprojectdocs( $name, $cfunc,
+"Unlike L<cumu$func|/cumu$func>, the calculations are performed in complex double\n" .
+"precision." ),
+	   );
+=cut
 } # foreach: my $func
 
 
@@ -254,7 +307,7 @@ foreach my $func ( sort keys %over ) {
 
     my %extra = {};
     unless ( defined $over{$func}{alltypes} and $over{$func}{alltypes} ) {
-	$extra{GenericTypes} = ['B','S','U','L','N'];
+	$extra{GenericTypes} = $INT,
     }
 
     pp_def(
@@ -391,6 +444,31 @@ pp_addpm(<<'EOD');
 EOD
 
 
+# do the above calculation, but in complex double precision
+pp_def(
+	'caverage',
+	HandleBad => 1,
+	Pars => 'a(n); cdouble [o]b();',
+	Code =>
+	'complex double tmp = 0;
+	if($SIZE(n)) {
+	 loop(n) %{ tmp += $a(); %}
+	 $b() = tmp / $SIZE(n);
+	}
+	  else { $b() = 0; }',
+	BadCode =>
+	'complex double tmp = 0;
+         PDL_Indx cnt = 0;
+	 loop(n) %{
+            if ( $ISGOOD(a()) ) { tmp += $a(); cnt++; }
+         %}
+         if ( cnt ) { $b() = tmp / cnt; }
+         else       { $SETBAD(b()); }',
+	Doc => projectdocs( 'average', 'daverage',
+"Unlike L<average|/average>, the calculation is performed in complex double\n" .
+"precision." ),
+	);
+
 # do the above calculation, but in double precision
 pp_def( 
 	'daverage',
@@ -440,6 +518,7 @@ EOD
 for ( PDL::Types::typesrtkeys() ) {
     my $ctype = $PDL::Types::typehash{$_}{ctype};
     my $ppsym = $PDL::Types::typehash{$_}{ppsym};
+	next if (grep { $ppsym =~ m/$_/ } @$C ); # sorting of complex numbers not well defined
 
     pp_add_boot( " PDL->qsort_${ppsym} = pdl_qsort_${ppsym};" .
 		 " PDL->qsort_ind_${ppsym} = pdl_qsort_ind_${ppsym};\n" );
@@ -696,7 +775,7 @@ some circumstances.
 pp_def('modeover',
        HandleBad=>undef,
        Pars => 'data(n); [o]out(); [t]sorted(n);',
-       GenericTypes=>['B','S','U','L','Q','N'],
+       GenericTypes=>$INT,
        Doc=>projectdocs('mode','modeover','
 
 The mode is the single element most frequently found in a 
@@ -1314,6 +1393,7 @@ for my $which (
     pp_def( 
 	    $name,
 	    HandleBad => 1,
+	    GenericTypes=>$R,
 	    Pars => 'a(n); [o]c();', 
 	    Code => 
 	    '$GENERIC() cur;
@@ -1357,6 +1437,7 @@ for ways of masking NaNs.
     pp_def( 
 	    "${name}_ind",
 	    HandleBad => 1,
+	    GenericTypes=>$R,
 	    Pars => 'a(n); indx [o] c();', 
 	    Code => 
 	    '$GENERIC() cur;
@@ -1401,6 +1482,7 @@ otherwise the bad flag is cleared for the output piddle.',
     pp_def( 
 	    "${name}_n_ind",
 	    HandleBad => 0,   # just a marker 
+	    GenericTypes=>$R,
 	    Pars => 'a(n); indx [o]c(m);',
 	    Code =>
 	    '$GENERIC() cur; PDL_Indx curind; register PDL_Indx ns = $SIZE(n);
@@ -1525,6 +1607,7 @@ EOD
 pp_def( 
 	'minmaximum',
 	HandleBad => 1,
+	GenericTypes=>$R,
 	Pars => 'a(n); [o]cmin(); [o] cmax(); indx [o]cmin_ind(); indx [o]cmax_ind();',
 	Code => 
 	'$GENERIC() curmin, curmax;

--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+- native support for complex numbers - thanks @fantasma13
+
 2.026 2021-02-13
 - fix GSL build errors, improve docs - thanks @d-lamb
 - rfits properly treats BLANK in rice-compressed - thanks @d-lamb

--- a/Graphics/IIS/iis.pd
+++ b/Graphics/IIS/iis.pd
@@ -457,6 +457,7 @@ pp_bless('PDL::Graphics::IIS');
 
 pp_def('_iis',
         Pars => 'image(m,n); min(); max();',
+        GenericTypes=>['B','S','U','L','N','F','D'],
         OtherPars => 'char *perl_title',
 	Doc  => undef,
         Code => '

--- a/Lib/FFT/fft.pd
+++ b/Lib/FFT/fft.pd
@@ -145,6 +145,7 @@ use PDL::Core qw/:Func/;
 use PDL::Basic qw/:Func/;
 use PDL::Types;
 use PDL::ImageND qw/kernctr/; # moved to ImageND since FFTW uses it too
+use PDL::Ops qw/ci cimag creal/;
 
 END {
   # tidying up required after using fftn
@@ -163,7 +164,8 @@ sub todecimal {
 
 =for ref
 
-Complex 1-D FFT of the "real" and "imag" arrays [inplace].
+Complex 1-D FFT of the "real" and "imag" arrays [inplace]. A single
+cfloat/cdouble input piddle can also be used.
 
 =for sig
 
@@ -179,13 +181,19 @@ fft($real,$imag);
 
 sub PDL::fft {
 	# Convert the first argument to decimal and check for trouble.
-	eval {	todecimal($_[0]);	};
+	my $re=$_[0];
+	my $im=$_[1];
+	if ($re->type =~ m/cdouble|cfloat/) {
+		$im=cimag($re);
+		$re=creal($re);
+	}
+	eval {	todecimal($re);	};
 	if ($@) {
 		$@ =~ s/ at .*//s;
 		barf("Error in FFT with first argument: $@");
 	}
 	# Convert the second argument to decimal and check for trouble.
-	eval {	todecimal($_[1]);	};
+	eval {	todecimal($im);	};
 	if ($@) {
 		$@ =~ s/ at .*//s;
 		my $message = "Error in FFT with second argument: $@";
@@ -193,7 +201,12 @@ sub PDL::fft {
 			if ($message =~ /undefined value/);
 		barf($message);
 	}
-	_fft($_[0],$_[1]);
+	_fft($re,$im);
+	if ($_[0]->type =~ m/cdouble|cfloat/) {
+		$_[0]= $re+ci()*$im;
+	} else {
+		$_[0]=$re,$_[1]=$im;
+	}
 }
 
 
@@ -201,7 +214,8 @@ sub PDL::fft {
 
 =for ref
 
-Complex inverse 1-D FFT of the "real" and "imag" arrays [inplace].
+Complex inverse 1-D FFT of the "real" and "imag" arrays [inplace]. A single
+cfloat/cdouble input piddle can also be used.
 
 =for sig
 
@@ -217,13 +231,19 @@ ifft($real,$imag);
 
 sub PDL::ifft {
 	# Convert the first argument to decimal and check for trouble.
-	eval {	todecimal($_[0]);	};
+	my $re=$_[0];
+	my $im=$_[1];
+	if ($re->type =~ m/cdouble|cfloat/) {
+		$im=cimag($re);
+		$re=creal($re);
+	}
+	eval {	todecimal($re);	};
 	if ($@) {
 		$@ =~ s/ at .*//s;
 		barf("Error in FFT with first argument: $@");
 	}
 	# Convert the second argument to decimal and check for trouble.
-	eval {	todecimal($_[1]);	};
+	eval {	todecimal($im);	};
 	if ($@) {
 		$@ =~ s/ at .*//s;
 		my $message = "Error in FFT with second argument: $@";
@@ -231,7 +251,12 @@ sub PDL::ifft {
 			if ($message =~ /undefined value/);
 		barf($message);
 	}
-	_ifft($_[0],$_[1]);
+	_ifft($re,$im);
+	if ($_[0]->type =~ m/cdouble|cfloat/) {
+		$_[0]= $re+ci()*$im;
+	} else {
+		$_[0]=$re,$_[1]=$im;
+	}
 }
 
 =head2 realfft()
@@ -312,6 +337,10 @@ N-dimensional FFT over all pdl dims of input (inplace)
 sub PDL::fftnd {
     barf "Must have real and imaginary parts for fftnd" if $#_ != 1;
     my ($r,$i) = @_;
+    if ($r->type =~m/cdouble|cfloat/ ) {
+	$i=cimag $r;
+	$r=creal $r;
+    }
     my ($n) = $r->getndims;
     barf "Dimensions of real and imag must be the same for fft"
         if ($n != $i->getndims);
@@ -325,7 +354,11 @@ sub PDL::fftnd {
       $r = $r->mv(0,$n);
       $i = $i->mv(0,$n);
     }
-    $_[0] = $r; $_[1] = $i;
+    if ($_[0]->type =~m/cdouble|cfloat/ ) {
+	$_[0]=$r+ci()*$i;
+    } else {
+	$_[0] = $r; $_[1] = $i;
+    }
     undef;
 }
 
@@ -346,6 +379,10 @@ N-dimensional inverse FFT over all pdl dims of input (inplace)
 sub PDL::ifftnd {
     barf "Must have real and imaginary parts for ifftnd" if $#_ != 1;
     my ($r,$i) = @_;
+    if ($r->type =~m/cdouble|cfloat/ ) {
+	$r=creal $r;
+	$i=cimag $r;
+    }
     my ($n) = $r->getndims;
     barf "Dimensions of real and imag must be the same for ifft"
         if ($n != $i->getndims);
@@ -359,7 +396,11 @@ sub PDL::ifftnd {
       $r = $r->mv(0,$n);
       $i = $i->mv(0,$n);
     }
-    $_[0] = $r; $_[1] = $i;
+    if ($_[0]->type =~m/cdouble|cfloat/ ) {
+	$_[0]=$r+ci()*$i;
+    } else {
+	$_[0] = $r; $_[1] = $i;
+    }
     undef;
 }
 
@@ -491,6 +532,10 @@ sub PDL::fftconvolve {
 sub PDL::fftconvolve_inplace {
     barf "Must have image & kernel for fftconvolve" if $#_ != 1;
     my ($hr, $hi) = @_;
+    if ($hr->type =~m/cdouble|cfloat/) {
+	$hi=cimag($hr);
+	$hr=creal($hr);
+    }
     my ($n) = $hr->getndims;
     todecimal($hr);   # Convert to double unless already float or double
     todecimal($hi);   # Convert to double unless already float or double
@@ -516,8 +561,14 @@ sub PDL::fftconvolve_inplace {
     $hr->clump(-1)->set(0,$hr->clump(-1)->at(0)*2);
     $hi->clump(-1)->set(0,0.);
     ifftnd($hr,$hi);
-    $_[0] = $hr; $_[1] = $hi;
-    ($hr,$hi);
+    # convert back to complex if input was complex
+    if ($_[0]->type =~m/cdouble|cfloat/) {
+	$_[0]=$hr+ci()*$hi;
+	return $_[0];
+    } else {
+        $_[0] = $hr; $_[1] = $hi;
+        return ($hr,$hi);
+    }
 }
 
 EOD
@@ -527,6 +578,7 @@ EOD
 
 pp_def('convmath',
 	Pars => '[o,nc]a(m); [o,nc]b(m);',
+	GenericTypes=>['B','S','U','L','N','F','D'],
 	Code => '
 	$GENERIC() t1, t2;
 	loop(m) %{
@@ -542,6 +594,7 @@ pp_def('convmath',
 
 pp_def('cmul',
 	Pars => 'ar(); ai(); br(); bi(); [o]cr(); [o]ci();',
+	GenericTypes=>['B','S','U','L','N','F','D'],
 	Code => '
 	$GENERIC() ar, ai, br, bi;
 	   ar = $ar();
@@ -572,6 +625,7 @@ our $abs_string .= "types($_) %{" . $ah{$_} . '(br) > ' . $ah{$_} . "(bi)%}\n" f
 
 pp_def('cdiv',
 	Pars => 'ar(); ai(); br(); bi(); [o]cr(); [o]ci();',
+	GenericTypes=>['B','S','U','L','N','F','D'],
 	Code => '
 	$GENERIC() ar, ai, br, bi, tt, dn;
 	   ar = $ar();

--- a/Lib/Image2D/image2d.pd
+++ b/Lib/Image2D/image2d.pd
@@ -140,6 +140,7 @@ my %pnpolyFields = (
 for my $name (sort keys %pnpolyFields) {
 	pp_def($name,
 		HandleBad => 0,
+		GenericTypes=>['B','S','U','L','N','F','D'],
 		PMFunc => '',
 		Doc => undef,
 		Pars => $pnpolyFields{$name}->{'pars'},
@@ -195,8 +196,8 @@ pp_addhdr('
 
 for ( PDL::Types::typesrtkeys() ) {
     my $ctype = $PDL::Types::typehash{$_}{ctype};
+    next if $ctype =~ /C/; # filter complex
     my $ppsym = $PDL::Types::typehash{$_}{ppsym};
-
   pp_addhdr << "EOH";
 
 /*
@@ -621,6 +622,7 @@ Note: this routine does the median over all points in a rectangular
 
 EOD
         Pars => 'a(m,n); [o]b(m,n);',
+        GenericTypes=>['B','S','U','L','N','F','D'],
 	# funny parameter names to avoid special case in 'init_vars'
         OtherPars => 'int __p_size; int __q_size; int opt;',
         PMCode => '
@@ -939,6 +941,7 @@ EOD
 
        HandleBad => 1,
         Pars => 'a(m,n); [o]val(); int [o]x(); int[o]y();',
+        GenericTypes=>['B','S','U','L','N','F','D'],
         Code => '
         double cur; int curind1; int curind2;
         curind1=0;
@@ -1157,6 +1160,7 @@ where the second parameter specifies the connectivity (4 or 8) of the labeling.
 ',
        HandleBad => 0, # a marker
         Pars => 'a(m,n); int+ [o]b(m,n);',
+        GenericTypes=>['B','S','U','L','N','F','D'],
         OtherPars => 'int con',
         Code => '
 
@@ -1530,6 +1534,7 @@ EOD
 pp_def('bilin2d',
        HandleBad => 0,
     Pars => 'Int(n,m); O(q,p)',
+    GenericTypes=>['B','S','U','L','N','F','D'],
     Doc=><<'EOD',
 
 =for ref
@@ -1577,6 +1582,7 @@ EOD
 pp_def('rescale2d',
        HandleBad => 0,
     Pars => 'Int(m,n); O(p,q)',
+    GenericTypes=>['B','S','U','L','N','F','D'],
     Doc=><<'EOD',
 
 =for ref

--- a/MANIFEST
+++ b/MANIFEST
@@ -747,6 +747,7 @@ t/matrixops.t
 t/minmax-behavior.t
 t/minuit.t
 t/misc.t
+t/nat_complex.t
 t/niceslice.t
 t/nsdatahandle.t
 t/ones.t
@@ -754,6 +755,7 @@ t/op-eq-warn-for-non-numeric.t
 t/opengl.t
 t/ops-bitwise.t
 t/ops.t
+t/ops_complex.t
 t/pdl-from-string-bad-values.t
 t/pdl_from_string.t
 t/pdlchar.t

--- a/t/fft.t
+++ b/t/fft.t
@@ -4,7 +4,7 @@ use PDL;
 use PDL::Image2D;
 use PDL::FFT;
 
-use Test::More tests => 17;
+use Test::More tests => 22;
 use Test::Exception;
 
 sub tapprox {
@@ -14,7 +14,7 @@ sub tapprox {
 
 my ( $pa, $pb, $pc, $pi, $pk, $kk );
 
-foreach my $type(double,float){
+foreach my $type(double,float,cdouble,cfloat){
   $pa = pdl($type,1,-1,1,-1);
   $pb = zeroes($type,$pa->dims);
   fft($pa,$pb);
@@ -28,9 +28,13 @@ $pa = rfits("m51.fits");
 
 $pb = $pa->copy;
 $pc = $pb->zeroes;
+my $pd=$pb+ci()*$pc;
 fft($pb,$pc);
 ifft($pb,$pc);
+fft($pd);
+ifft($pd);
 ok (tapprox($pc,0), "fft zeroes");
+ok (tapprox(cimag($pd),0), "fft zeroes using complex piddles");
 
 #print "\n",$pc->info("Type: %T Dim: %-15D State: %S"),"\n";
 #print "Max: ",$pc->max,"\n";

--- a/t/nat_complex.t
+++ b/t/nat_complex.t
@@ -1,0 +1,91 @@
+use PDL::LiteF;
+#use PDL::Complex;
+use PDL::Config;
+
+BEGIN {
+   use Test::More tests => 16;
+}
+
+sub tapprox {
+        my($x,$y) = @_;
+        my $c = abs($x-$y);
+        my $d = max($c);
+        $d < 0.0001;
+}
+
+$ref = pdl([[-2,1],[-3,1]]);
+$ref2 = squeeze($ref->slice("0,")+ci()*$ref->slice("1,"));
+$x = ci() -pdl (-2, -3);
+
+ok($x->type eq 'cdouble', 'type promotion i - piddle');
+ok(tapprox($x->cimag,$ref->slice("1,:")), 'value from i - piddle');
+
+$x = cdouble (2,3);
+$x-=3*ci();
+ok(type ($x) eq 'cdouble', 'type promption piddle - i');
+$y=cfloat($x);
+ok(type ($y) eq 'cfloat', 'type conversion to cfloat');
+ok(tapprox($x->cimag,$ref->slice("0,1")), 'value from piddle - i');
+
+# dataflow from complex to real
+$ar = $x->creal;
+$ar++;
+ok(tapprox($x->creal, -$ref->slice("0,")->squeeze), 'no complex to real dataflow');
+$x+=ci;
+ok(tapprox($x->cimag, -$ref->slice("1,")*2), 'no dataflow after conversion');
+
+# Check that converting from re/im to mag/ang and
+#  back we get the same thing
+$x = $ref2->copy;
+my $a=abs($x);
+my $p=carg($x);
+
+my $y = $a*cos($p)+ci()*$a*sin($p);
+ok(tapprox($x-$y, 0.), 'check re/im and mag/ang equivalence');
+
+# to test Cabs, Cabs2, Carg (ref PDL)
+# Catan, Csinh, Ccosh, Catanh, Croots
+
+$cabs = sqrt($x->creal**2+$x->cimag**2);
+
+ok(ref abs $x eq 'PDL', 'Cabs type');
+ok(ref carg ($x) eq 'PDL', 'Carg type');
+ok(tapprox($cabs, abs $x), 'Cabs value');
+#ok(tapprox($cabs**2, Cabs2 $x), 'Cabs2 value');
+
+# Check cat'ing of PDL::Complex
+$y = $x->creal->copy + 1;
+my $bigArray = $x->cat($y);
+#ok(abs($bigArray->sum() +  8 - 4*ci()) < .0001, 'check cat for PDL::Complex');
+
+my $z = pdl(0) + ci()*pdl(0);
+$z **= 2;
+
+ok($z->creal->at(0) == 0 && $z->cimag->at(0) == 0, 'check that 0 +0i exponentiates correctly'); # Wasn't always so.
+
+
+my $zz = $z ** 0;
+
+ok($zz->creal->at(0) == 1 && $zz->cimag->at(0) == 0, 'check that 0+0i ** 0 is 1+0i');
+
+$z **= $z;
+
+ok($z->creal->at(0) == 1 && $z->cimag->at(0) == 0, 'check that 0+0i ** 0+0i is 1+0i');
+
+my $r = pdl(-10) + ci()*pdl(0);
+$r **= 2;
+
+ok($r->creal->at(0) < 100.000000001 && $r->creal->at(0) > 99.999999999 && $r->cimag->at(0) == 0,
+  'check that imaginary part is exactly zero'); # Wasn't always so
+
+TODO: {
+   local $TODO = "Known_problems sf.net bug #1176614" if ($PDL::Config{SKIP_KNOWN_PROBLEMS} or exists $ENV{SKIP_KNOWN_PROBLEMS} );
+
+
+   # Check stringification of complex piddle
+   # This is sf.net bug #1176614
+   my $c =  9.1234 + 4.1234*ci;
+   my $c211 = $c->dummy(2,1);
+   my $c211str = "$c211";
+   ok($c211str=~/(9.123|4.123)/, 'sf.net bug #1176614');
+}

--- a/t/ops_complex.t
+++ b/t/ops_complex.t
@@ -1,0 +1,254 @@
+use Test::More tests => 64;
+use PDL::LiteF;
+use PDL::NiceSlice;
+use Config;
+kill INT,$$ if $ENV{UNDER_DEBUGGER}; # Useful for debugging.
+use Test::Exception;
+
+use strict;
+use warnings;
+
+kill 'INT',$$ if $ENV{UNDER_DEBUGGER}; # Useful for debugging.
+
+approx(pdl(0), pdl(0), 0.01); # set eps
+
+# $a0 = zeroes cdouble,3,5;
+# $b0 = xvals $a0;
+{
+my $pa = xvals (cdouble,3,5) + 10 -2*  xvals (3,5)*ci;
+
+my $pb = yvals (cdouble,3,5)+ 10 -2* yvals (3,5)*ci;
+
+my $pc = $pa + $pb;
+
+ok($pc->double->at(2,2) == 4+6*ci, 'pdl addition 1');
+ok($pc(2,3) == cdouble (5 +ci*4), 'pdl addition 2');
+#throws_ok {$pc(2,3) > (5 +ci*4); } 'pdl comparison 2';
+throws_ok {
+	$pc->at(3,3);
+} qr/Position out of range/, 'invalid position';
+}
+
+{
+my $pd = cdouble 5,6;
+
+my $pe = $pd - 1;
+ok($pe->at(0) eq '4+0i', 'pdl - scalar 1');
+ok($pe->at(1) == 5, 'pdl - scalar 2');
+my $pf = 1 - $pd;
+ok($pf->at(0) == -4, 'scalar - pdl 1');
+ok($pf->at(1) == -5, 'scalar - pdl 2');
+}
+
+# Now, test one operator from each group
+# biop1 tested already
+{
+my $pa = pdl 0,1,2;
+my $pb = pdl 1.5;
+
+my $pc = $pa > $pb;
+
+ok($pc->at(1) == 0, '0 not > 1.5');
+ok($pc->at(2) == 1, '2 is > 1.5');
+}
+
+{
+my $pa = byte pdl 0,1,3;
+my $pc = $pa << 2;
+
+ok($pc->at(0) == 0, '0 left bitshift 2 is 0');
+ok($pc->at(0) != 1, '0 left bitshift 2 is 0');
+ok($pc->at(1) == 4, '1 left bitshift 2 is 4');
+ok($pc->at(2) == 12,'3 left bitshift 2 is 12');
+}
+
+{
+my $pa = cdouble pdl 16,64,9,-1;
+my $pb = sqrt($pa);
+
+ok(ci()**2 == -1,'i squared = -1');
+ok(all( approx($pb,(cdouble 4,8,3,ci()))),'sqrt of pdl(16,64,9,-1)');
+
+# See that a is unchanged.
+
+ok($pa->at(0) == 16, 'sqrt orig value ok');
+}
+
+{
+my $pa = pdl 1,0;
+my $pb = ! $pa;
+ok($pb->at(0) == 0, 'elementwise not 1');
+ok($pb->at(1) == 1, 'elementwise not 2');
+}
+
+{
+my $pa = pdl 12,13,14,15,16,17;
+my $pb = $pa % 3;
+
+ok($pb->at(0) == 0, 'simple modulus 1');
+ok($pb->at(1) == 1, 'simple modulus 2');
+ok($pb->at(3) == 0, 'simple modulus 3');
+# [ More modulus testing farther down! ]
+}
+
+{
+# Might as well test this also
+ok(all( approx((pdl 2,3),(pdl 2,3))),'approx equality 1');
+ok(!all( approx((pdl 2,3),(pdl 2,4))),'approx equality 2');
+}
+
+{
+# Simple function tests
+my $pa = pdl(2,3);
+ok(all( approx(exp($pa), pdl(7.3891,20.0855))), 'exponential');
+ok(all( approx(sqrt($pa), pdl(1.4142, 1.7321))), 'sqrt makes decimal');
+}
+
+{
+# And and Or
+
+ok(all( approx(pdl(1,0,1) & pdl(1,1,0), pdl(1,0,0))), 'elementwise and');
+ok(all( approx(pdl(1,0,1) | pdl(1,1,0), pdl(1,1,1))), 'elementwise or');
+}
+
+{
+# atan2
+ok (all( approx(atan2(pdl(1,1), pdl(1,1)), ones(2) * atan2(1,1))), 'atan2');
+}
+
+{
+my $pa = sequence (3,4);
+my $pb = sequence (3,4) + 1;
+
+ok (all( approx($pa->or2($pb,0), $pa | $pb)), 'or2');
+ok (all( approx($pa->and2($pb,0), $pa & $pb)), 'and2');
+ok (all( approx($pb->minus($pa,0), $pb - $pa)), 'explicit minus call');
+ok (all( approx($pb - $pa, ones(3,4))), 'pdl subtraction');
+}
+
+# inplace tests
+
+{
+my $pa = cdouble 1;
+my $sq2 = sqrt 2; # perl sqrt
+
+$pa->inplace->plus(1,0);  # trailing 0 is ugly swap-flag
+ok(all( approx($pa, pdl 2)), 'inplace plus');
+my $warning_shutup;
+$warning_shutup = $warning_shutup = sqrt $pa->inplace;
+ok(all( approx( $pa, pdl($sq2))), 'inplace pdl sqrt vs perl scalar sqrt');
+my $pb = pdl 4;
+ok(all( approx( 2, sqrt($pb->inplace))),'perl scalar vs inplace pdl sqrt');
+}
+
+{
+# log10 now uses C library
+# check using scalars and piddles
+{
+my $pa = 20+10*ci;
+my $pb = log ($pa);
+note "a: $pa  [ref(\$pa)='", ref($pa),"']\n";
+note "b: $pb\n";
+ok(exp($pb)-$pa < 1.0e-5 ,'exp of log of complex scalar');
+}
+
+{
+my $pa = log10(pdl(110,23));
+my $pb = log(pdl(110,23)) / log(10);
+note "a: $pa\n";
+note "b: $pb\n";
+ok(all( approx( $pa, $pb)), 'log10 pdl');
+
+# check inplace
+ok(all( approx( cdouble(110,23)->inplace->log()/log(10), $pb)), 'inplace pdl log10');
+}
+
+}
+
+{
+my $data = ones cdouble,5;
+$data+=ci();
+$data &= 0;
+ok(all($data == 0), 'and assign');
+$data |= 1;
+ok(all($data == 1), 'or assign');
+
+ok(all($data eq $data), 'eq'); # check eq operator
+}
+
+SKIP:
+{
+  skip("ipow skipped without 64bit support", 1) if $Config{ivsize} < 8;
+  # check ipow routine
+  my $xdata = indx(0xeb * ones(8));
+  my $n = sequence(indx,8);
+  my $exact = indx(1,235,55225,12977875,3049800625,716703146875,168425239515625,39579931286171875);
+  ok(all($exact - ipow($xdata,$n) == indx(0)), 'ipow');
+}
+
+#### Modulus checks ####
+
+{
+#test signed modulus on small numbers
+# short/long/indx/longlong/float/double neg/0/pos % neg/0/pos
+my $pa = pdl(-7..7);
+my $pb = pdl(-3,0,3)->transpose;
+my $pc = cat(pdl("-1 0 -2 " x 5),zeroes(15),pdl("2 0 1 " x 5));
+ok all(short($pa) % short($pb) == short($pc)),'short modulus';
+ok all(long($pa) % long($pb) ==  long($pc)), 'long modulus';
+ok all(indx($pa) % indx($pb) == indx($pc)), 'indx modulus';
+ok all(longlong($pa) % longlong($pb) == longlong($pc)), 'longlong modulus';
+ok all(float($pa) % float($pb) == float($pc)), 'float modulus';
+ok all(double($pa) % double($pb) == double($pc)), 'double modulus';
+}
+
+{
+#test unsigned modulus
+# byte/ushort 0/pos % 0/pos
+my $pa = xvals(15);
+my $pb = pdl(0,3)->transpose;
+my $pc = cat(zeroes(15),pdl("0 1 2 " x 5));
+ok all(byte($pa) % byte($pb)==byte($pc)), 'byte modulus';
+ok all(ushort($pa) % ushort($pb)==ushort($pc)), 'ushort modulus';
+}
+
+#and for big numbers (bigger than INT_MAX=2147483647)
+#basically this is exercising the (typecast)(X)/(N) in the macros
+my $INT_MAX = 2147483647;
+
+TODO: {
+local $TODO = undef;
+$TODO = 'Marking TODO for big modulus for 2.008 release';
+require Config;
+diag "\$Config{ivsize} = $Config::Config{ivsize}";
+diag "\$INT_MAX = $INT_MAX = @{[ sprintf '%x', $INT_MAX ]}";
+cmp_ok long($INT_MAX)%1      , '==', 0, "big long modulus: $INT_MAX % 1";
+cmp_ok indx($INT_MAX*4)%2    , '==', 0, "big indx modulus: @{[$INT_MAX*4]} % 2";
+cmp_ok longlong($INT_MAX*4)%2, '==', 0, "big longlong modulus: @{[$INT_MAX*4]} % 2";
+#skip float intentionally here, since float($INT_MAX)!=$INT_MAX
+cmp_ok double($INT_MAX*4)%2  , '==', 0, "big double modulus: @{[$INT_MAX*4]} % 2";
+}
+
+{
+#and do the same for byte (unsigned char) and ushort
+my $BYTE_MAX = 255;
+my $USHORT_MAX = 65535;
+
+ok byte($BYTE_MAX)%1 == 0, 'big byte modulus';
+ok ushort($USHORT_MAX)%1 == 0, 'big ushort modulus';
+}
+
+SKIP:
+{
+  skip("your perl hasn't 64bit int support", 6) if $Config{ivsize} < 8;
+  # SF bug #343 longlong constructor and display lose digits due to implicit double precision conversions
+  cmp_ok longlong(10555000100001145) - longlong(10555000100001144),      '==', 1, "longlong precision/1";
+  cmp_ok longlong(9000000000000000002) - longlong(9000000000000000001),  '==', 1, "longlong precision/2";
+  cmp_ok longlong(-8999999999999999998) + longlong(8999999999999999999), '==', 1, "longlong precision/3";
+  cmp_ok longlong(1000000000000000001) - longlong(1000000000000000000),  '==', 1, "longlong precision/4";
+  cmp_ok longlong(9223372036854775807) - longlong(9223372036854775806),  '==', 1, "longlong precision/5";
+  cmp_ok longlong(9223372036854775807) + longlong(-9223372036854775808), '==',-1, "longlong precision/6";
+}
+
+is(~pdl(1,2,3)              ."", '[-2 -3 -4]', 'bitwise negation');
+is((pdl(1,2,3) ^ pdl(4,5,6))."", '[5 7 5]'   , 'bitwise xor'     );


### PR DESCRIPTION
Hi,
please checkout this branch for native complex support. It should hopefully apply against master without too many problems. 

I'm unsure of the changes to header file includes, in particular the proto.h caused issues, I'm not sure why it is required. It compiles fine and all tests pass on gcc 64 bit linux but I haven't tested other platforms. capn testers reports would be welcome for this.

The perldl.conf file may be modified, in particular testing the various bad value related options. 
There are a few substantial changes in the Core directory, Types.pm.PL, of course, and in particular the anyval_to_nayval function was moved to pdlcore.h.PL. Complex math is particular, so some spraying of GENERICTYPE was necessary throughout the ops, ufunc and math libs as well as some others.

For future support, I've added a few flags to data types (whether it's real or complex, integer or not and one for signed/unsigned. They are not (widely) used yet but could potentially facilitate writing fairly generic code. Feel free to scrap the idea if you don't like it.

Ingo