### PR TITLE
Fix spelling errors.

### DIFF
--- a/Basic/Slices/slices.pd
+++ b/Basic/Slices/slices.pd
@@ -2790,7 +2790,7 @@ in the original PDL some number of times.  An asterisk followed
 by a number produces a dummy dimension in the output, for
 example C<< *2 >> will generate a dimension of size 2 at
 the corresponding location in the output dim list.  Omitting
-the numeber (and using just an asterisk) inserts a dummy dimension
+the number (and using just an asterisk) inserts a dummy dimension
 of size 1.
 
 =back

--- a/Graphics/IIS/iis.pd
+++ b/Graphics/IIS/iis.pd
@@ -204,7 +204,7 @@ Draws a circle on a IIS device (e.g. SAOimage/Ximtool)
 
  iiscirc $x, $y, [$radius, $colour]
 
-Draws circles on the IIS device with specied points and colours. Because
+Draws circles on the IIS device with specified points and colours. Because
 this module uses 
 L<PDL::PP|PDL::PP> threading you can supply lists of points via
 1D arrays, etc.

--- a/Graphics/TriD/Rout/rout.pd
+++ b/Graphics/TriD/Rout/rout.pd
@@ -247,7 +247,7 @@ missing data values.
 
 =over 4
 
-=item Algorthym
+=item Algorithm
 
 The data array represents samples of some field observed on the surface described 
 by points.  For each contour value we look for intersections on the line segments

--- a/Graphics/TriD/TriD/Contours.pm
+++ b/Graphics/TriD/TriD/Contours.pm
@@ -59,7 +59,7 @@ value using the set_color_table function.
   Font =>  $font      # explicitly set the font for contour labels
 
   If ContourVals is specified ContourInt, ContourMin, and ContourMax
-  are ignored.  If no options are specified, the algorthym tries to
+  are ignored.  If no options are specified, the algorithm tries to
   choose values based on the data supplied.  Font can also be specified or
   overwritten by the addlabels() function below.
 

--- a/IO/HDF/HDF.pm
+++ b/IO/HDF/HDF.pm
@@ -51,7 +51,7 @@ use PDL::IO::HDF::VS;
 
 =head1 CONSTANTS
 
-These constants are now implented using the perl 'use constant' pragma.
+These constants are now implemented using the perl 'use constant' pragma.
 
 Previously, they were just scalars that were changeable (which is a no-no).
 


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for the Debian package build of 2.020:

 * specied   -> specified
 * algorthym -> algorithm
 * implented -> implemented
 * numeber   -> number