### PR TITLE
Fix pdlpp_postamble oneliner.

### DIFF
--- a/Basic/Core/Dev.pm
+++ b/Basic/Core/Dev.pm
@@ -424,7 +424,7 @@ sub pdlpp_postamble {
 	join '',map { my($src,$pref,$mod) = @$_;
 	my $w = whereami_any();
 	$w =~ s%/((PDL)|(Basic))$%%;  # remove the trailing subdir
-	my $oneliner = _oneliner(q{exit if \$\$ENV{DESTDIR}; use PDL::Doc; eval { PDL::Doc::add_module(q{$mod}); }});
+	my $oneliner = _oneliner(q{exit if \$ENV{DESTDIR}; use PDL::Doc; eval { PDL::Doc::add_module(q{$mod}); }});
 qq|
 
 $pref.pm: $src


### PR DESCRIPTION
Building PDL::NetCDF failed with:
```
Updating PDL documentation database...
"/usr/bin/perl"  -e 'exit if \$\$ENV{DESTDIR}; use PDL::Doc; eval { PDL::Doc::add_module(q{$mod}); }' --
Scalar found where operator expected at -e line 1, near "$\$ENV"
        (Missing operator before $ENV?)
syntax error at -e line 1, near "$\$ENV"
BEGIN not safe after errors--compilation aborted at -e line 1.
```