### PR TITLE
Squash whitespace-only string in Makefile.PL to quiet EU::MM

### DIFF
--- a/Basic/Core/Makefile.PL
+++ b/Basic/Core/Makefile.PL
@@ -239,7 +239,7 @@ WriteMakefile(
  'PL_FILES'     => {map {($_ => nopl $_)} grep {!/^Makefile.PL$/} <*.PL>},
  'OBJECT'       => 'Core$(OBJ_EXT) ' . $cobj,
  'DEFINE' 	=> $pthread_define.$badval_define,
- 'LIBS'         => ["$pthread_library $malloclib"],
+ 'LIBS'         => ["$pthread_library $malloclib" =~ s/^ $//r],
  'clean'        => {'FILES'  => $cobj .
                    ' pdlconv.c pdlsections.c pdlcore.c '.
 		   'pdl.h pdlsimple.h pdlcore.h '.

--- a/Basic/Core/Makefile.PL
+++ b/Basic/Core/Makefile.PL
@@ -220,6 +220,9 @@ pdlcore.c:: pdlcore.c.PL Types.pm\n"
 }
 };
 
+my $libs_string = "$pthread_library $malloclib";
+$libs_string =~ s/^ $//;
+
 my @cfiles = qw(pdlcore pdlapi pdlhash pdlthread pdlconv pdlmagic pdlsections);
 my $cobj = join ' ', map qq{$_\$(OBJ_EXT)}, @cfiles;
 WriteMakefile(
@@ -239,7 +242,7 @@ WriteMakefile(
  'PL_FILES'     => {map {($_ => nopl $_)} grep {!/^Makefile.PL$/} <*.PL>},
  'OBJECT'       => 'Core$(OBJ_EXT) ' . $cobj,
  'DEFINE' 	=> $pthread_define.$badval_define,
- 'LIBS'         => ["$pthread_library $malloclib" =~ s/^ $//r],
+ 'LIBS'         => [$libs_string],
  'clean'        => {'FILES'  => $cobj .
                    ' pdlconv.c pdlsections.c pdlcore.c '.
 		   'pdl.h pdlsimple.h pdlcore.h '.


### PR DESCRIPTION
If both of these variables are empty, then the string here would
be just " ", and that would generate a few 'uninitialized' warnings
during 'perl Makefile.PL'. No major problem, but it looks bad.
This sets it to the empty string in that case.

This is a lot of notes for a 12-character addition but since it potentially effects all builds I wanted to have it looked at before pushing to master.