### PR TITLE
Add imageformat to IO::Pnm::Pic to export an access to chkform

### DIFF
--- a/IO/Pnm/Pic.pm
+++ b/IO/Pnm/Pic.pm
@@ -816,6 +816,10 @@ sub PDL::wmpeg {
 
 Figure out the format of an image file from its magic numbers, or else, from its extension.
 
+Currently recognized image formats are: PNM, GIF, TIFF, JPEG, SGI,
+RAST, IFF, PCX, PS, FITS, PNG.  If the format can not be determined,
+the string 'UNKNOWN' is returned.
+
 =for example
 
     $format=imageformat($path); # find out image format of certain file

--- a/IO/Pnm/Pic.pm
+++ b/IO/Pnm/Pic.pm
@@ -818,7 +818,7 @@ Figure out the format of an image file from its magic numbers, or else, from its
 
 =for example
 
-    $format=imageformat('image.jpg'); # find out format
+    $format=imageformat($path); # find out image format of certain file
     print "Unknown image format" if $format eq 'UNKNOWN';
     $canread=rpiccan($format); # check if this format is readable in this system
     if($canread){

--- a/IO/Pnm/Pic.pm
+++ b/IO/Pnm/Pic.pm
@@ -32,7 +32,7 @@ temporary directory). For this to work you need the program ffmpeg also.
 package PDL::IO::Pic;
 
 
-@EXPORT_OK = qw( wmpeg rim wim rpic wpic rpiccan wpiccan );
+@EXPORT_OK = qw( wmpeg rim wim rpic wpic rpiccan wpiccan imageformat);
 
 %EXPORT_TAGS = (Func => [@EXPORT_OK]);
 use PDL::Core;
@@ -577,7 +577,7 @@ sub rim {
 	  ) {
 	  $out =  $out->reorder(1,2,0);
       }
-      
+
       $dest .= $out;
       return $out;
   }
@@ -704,7 +704,7 @@ is used to determine the video encoder type.
   E.g.:
     .mpg for MPEG-1 encoding
     .mp4 for MPEG-4 encoding
-   
+
   And even:
     .gif for GIF animation (uncompressed)
 
@@ -810,7 +810,31 @@ sub PDL::wmpeg {
    return 1;
 }
 
+=head2 imageformat
 
+=for ref
+
+Figure out the format of an image file from its magic numbers, or else, from its extension.
+
+=for example
+
+    $format=imageformat('image.jpg'); # find out format
+    print "Unknown image format" if $format eq 'UNKNOWN';
+    $canread=rpiccan($format); # check if this format is readable in this system
+    if($canread){
+        $pdl=rpic($path) ; # attempt to read image ONLY if we can
+    } else {
+        print "Image can't be read\n"; # skip unreadable file
+    }
+
+=cut
+
+sub imageformat {PDL->imageformat(@_)}
+
+sub PDL::imageformat {
+    my($class, $file)=@_;
+    return chkform($file);
+}
 
 1; # Return OK status
 
@@ -870,11 +894,14 @@ sub chkext {
     return 'UNKNOWN';
 }
 
+
+
 # try to figure out the format of a supposed image file
 # from the magic numbers (numbers taken from magic in netpbm and
 # the file format routines in xv)
 # if no magics match try extension for non-magic file types
 #     todo: make more complete
+
 sub chkform {
     my $file = shift;
     my ($format, $magic, $len, $ext) = ("","",0,"");
@@ -905,7 +932,6 @@ sub chkform {
 
     return chkext(getext($file));    # then try extensions
 }
-
 
 # helper proc for wpic
 # process hints for direct converter control and try to guess from extension

--- a/t/picrgb.t
+++ b/t/picrgb.t
@@ -68,7 +68,7 @@ for (keys %formats) {
    }
 }
 
-my $ntests = 2 * (@allowed);
+my $ntests = 4 * (@allowed);
 if ($ntests < 1) {
   plan skip_all => "No tests";
 }
@@ -107,7 +107,13 @@ foreach my $form (sort @allowed) {
         skip "Error: '$@'$additional", 2 if $@;
         $im2->wpic($tbyte,{IFORM => $iform});
 
+	my $determined_format;
+	$determined_format = imageformat($tushort);
+	is($determined_format, $form, "image $tushort is format $form");
         my $in1 = rpic_unlink($tushort) unless $usherr;
+
+	$determined_format = imageformat($tbyte);
+	is($determined_format, $form, "image $tbyte is format $form");
         my $in2 = rpic_unlink($tbyte);
 
         my $comp = $im1 / PDL::ushort(mmax(depends_on($form),$arr->[1]));


### PR DESCRIPTION
Add a new exportable subroutine, imageformat, to PDL::IO::Pic, to give access to chkformat, so that a program can find out easily the format of an image file and then check if it can be openend before attempting, avoiding a possible failure.