### PR TITLE
Remove extrapolation code from PDL::GSL::INTERP.

### DIFF
--- a/Lib/GSL/INTERP/gsl_interp.pd
+++ b/Lib/GSL/INTERP/gsl_interp.pd
@@ -92,77 +92,64 @@ Example:
 
 =for ref
 
-The function eval returns the interpolating function at a given point. By default
-it will barf if you try to extrapolate, to comply silently if the point to be
-evaluated is out of range pass the option {Extrapolate => 1}
+The function eval returns the interpolating function at a given point.
+It will barf with an "input domain error" if you try to extrapolate.
+
 
 =for usage
 
 Usage:
 
-    $result = $spl->eval($points,$opt);
+    $result = $spl->eval($points);
 
 =for example
 
 Example:
 
     my $res = $spl->eval($x)
-    $res = $spl->eval($x,{Extrapolate => 0}) #same as above
-
-    # silently comply if $x is out of range
-    $res = $spl->eval($x,{Extrapolate => 1})
 
 =head2 deriv()
 
 =for ref
 
 The deriv function returns the derivative of the
-interpolating function at a given point. By default
-it will barf if you try to extrapolate, to comply silently if the point to be
-evaluated is out of range pass the option {Extrapolate => 1}
+interpolating function at a given point.
+It will barf with an "input domain error" if you try to extrapolate.
+
 
 =for usage
 
 Usage:
 
-    $result = $spl->deriv($points,$opt);
+    $result = $spl->deriv($points);
 
 =for example
 
 Example:
 
     my $res = $spl->deriv($x)
-    $res = $spl->deriv($x,{Extrapolate => 0}) #same as above
-
-    # silently comply if $x is out of range
-    $res = $spl->deriv($x,{Extrapolate => 1})
-
 
 =head2 deriv2()
 
 =for ref
 
 The deriv2 function returns the second derivative
-of the interpolating function at a given point. By default
-it will barf if you try to extrapolate, to comply silently if the point to be
-evaluated is out of range pass the option {Extrapolate => 1}
+of the interpolating function at a given point.
+It will barf with an "input domain error" if you try to extrapolate.
+
 
 
 =for usage
 
 Usage:
 
-    $result = $spl->deriv2($points,$opt);
+    $result = $spl->deriv2($points);
 
 =for example
 
 Example:
 
     my $res = $spl->deriv2($x)
-    $res = $spl->deriv2($x,{Extrapolate => 0}) #same as above
-
-    # silently comply if $x is out of range
-    $res = $spl->deriv2($x,{Extrapolate => 1})
 
 =head2 integ()
 
@@ -170,26 +157,20 @@ Example:
 
 The integ function returns the integral
 of the interpolating function between two points.
-By default it will barf if you try to extrapolate,
-to comply silently if one of the integration limits
-is out of range pass the option {Extrapolate => 1}
+It will barf with an "input domain error" if you try to extrapolate.
 
 
 =for usage
 
 Usage:
 
-    $result = $spl->integ($la,$lb,$opt);
+    $result = $spl->integ($la,$lb);
 
 =for example
 
 Example:
 
     my $res = $spl->integ($la,$lb)
-    $res = $spl->integ($x,$y,{Extrapolate => 0}) #same as above
-
-    # silently comply if $la or $lb are out of range
-    $res = $spl->eval($la,$lb,{Extrapolate => 1})
 
 =head1 BUGS
 
@@ -263,17 +244,10 @@ GSLERR(gsl_spline_init,( INT2PTR(gsl_spline *, $COMP(spl)), $P(x),$P(y),$SIZE(n)
 pp_addpm('
 sub eval{
   my $opt;
-  if (ref($_[$#_]) eq \'HASH\'){ $opt = pop @_; }
-  else{ $opt = {Extrapolate => 0}; }
   my ($obj,$x) = @_;
   my $s_obj = $$obj[0];
   my $a_obj = $$obj[1];
-  if($$opt{Extrapolate} == 0){
-    return eval_meat($x,$$s_obj,$$a_obj);
-  }
-  else{
-    return eval_meat_ext($x,$$s_obj,$$a_obj);
-  }
+  return eval_meat($x,$$s_obj,$$a_obj);
 }
 ');
 
@@ -295,30 +269,14 @@ pp_def('eval_meat',
         Code =>'
 GSLERR(gsl_spline_eval_e,( INT2PTR(gsl_spline *, $COMP(spl)), $x(), INT2PTR(gsl_interp_accel *, $COMP(acc)), $P(out)));
 ');
-pp_def('eval_meat_ext',
-        Pars => 'double x(); double [o] out();',
-        OtherPars => 'IV spl;IV acc;',
-        Doc => undef,
-        Code =>'
-$out() = gsl_spline_eval( INT2PTR(gsl_spline *, $COMP(spl)), $x(), INT2PTR(gsl_interp_accel *, $COMP(acc)));
-');
-
 
 
 pp_addpm('
 sub deriv{
-  my $opt;
-  if (ref($_[$#_]) eq \'HASH\'){ $opt = pop @_; }
-  else{ $opt = {Extrapolate => 0}; }
   my ($obj,$x) = @_;
   my $s_obj = $$obj[0];
   my $a_obj = $$obj[1];
-  if($$opt{Extrapolate} == 0){
-    return  eval_deriv_meat($x,$$s_obj,$$a_obj);
-  }
-  else{
-    return  eval_deriv_meat_ext($x,$$s_obj,$$a_obj);
-  }
+  return  eval_deriv_meat($x,$$s_obj,$$a_obj);
 }
 ');
 
@@ -329,28 +287,13 @@ pp_def('eval_deriv_meat',
 	Code =>'
 GSLERR(gsl_spline_eval_deriv_e,( INT2PTR(gsl_spline *, $COMP(spl)), $x(), INT2PTR(gsl_interp_accel *, $COMP(acc)), $P(out)));
 ');
-pp_def('eval_deriv_meat_ext',
-        Pars => 'double x(); double [o] out();',
-        OtherPars => 'IV spl;IV acc;',
-        Doc => undef,
-	Code =>'
-$out() = gsl_spline_eval_deriv( INT2PTR(gsl_spline *, $COMP(spl)), $x(), INT2PTR(gsl_interp_accel *, $COMP(acc)));
-');
 
 pp_addpm('
 sub deriv2{
-  my $opt;
-  if (ref($_[$#_]) eq \'HASH\'){ $opt = pop @_; }
-  else{ $opt = {Extrapolate => 0}; }
   my ($obj,$x) = @_;
   my $s_obj = $$obj[0];
   my $a_obj = $$obj[1];
-  if($$opt{Extrapolate} == 0){
-    return  eval_deriv2_meat($x,$$s_obj,$$a_obj);
-  }
-  else{
-    return  eval_deriv2_meat_ext($x,$$s_obj,$$a_obj);
-  }
+  return  eval_deriv2_meat($x,$$s_obj,$$a_obj);
 }
 ');
 
@@ -361,28 +304,13 @@ pp_def('eval_deriv2_meat',
 	Code =>'
 GSLERR(gsl_spline_eval_deriv2_e,( INT2PTR(gsl_spline *, $COMP(spl)), $x(), INT2PTR(gsl_interp_accel *, $COMP(acc)), $P(out)));
 ');
-pp_def('eval_deriv2_meat_ext',
-        Pars => 'double x(); double [o] out();',
-        OtherPars => 'IV spl;IV acc;',
-        Doc => undef,
-	Code =>'
-$out() = gsl_spline_eval_deriv2( INT2PTR(gsl_spline *, $COMP(spl)), $x(), INT2PTR(gsl_interp_accel *, $COMP(acc)));
-');
 
 pp_addpm('
 sub integ{
-  my $opt;
-  if (ref($_[$#_]) eq \'HASH\'){ $opt = pop @_; }
-  else{ $opt = {Extrapolate => 0}; }
   my ($obj,$la,$lb) = @_;
   my $s_obj = $$obj[0];
   my $a_obj = $$obj[1];
-  if($$opt{Extrapolate} == 0){
-    return eval_integ_meat($la,$lb,$$s_obj,$$a_obj);
-  }
-  else{
-    return eval_integ_meat_ext($la,$lb,$$s_obj,$$a_obj);
-  }
+  return eval_integ_meat($la,$lb,$$s_obj,$$a_obj);
 }
 ');
 
@@ -392,13 +320,6 @@ pp_def('eval_integ_meat',
         Doc => undef,
 	Code =>'
 GSLERR(gsl_spline_eval_integ_e,( INT2PTR(gsl_spline *, $COMP(spl)), $a(), $b(), INT2PTR(gsl_interp_accel *, $COMP(acc)),$P(out)));
-');
-pp_def('eval_integ_meat_ext',
-        Pars => 'double a(); double b(); double [o] out();',
-	OtherPars => 'IV spl;IV acc;',
-        Doc => undef,
-	Code =>'
-$out() = gsl_spline_eval_integ( INT2PTR(gsl_spline *, $COMP(spl)), $a(), $b(), INT2PTR(gsl_interp_accel *, $COMP(acc)));
 ');
 
 

--- a/t/gsl_interp.t
+++ b/t/gsl_interp.t
@@ -38,10 +38,10 @@ ok(abs($spl->eval(5.5)-237.641810667697) < 1e-6,  'eval 5.5'   );
 ok(abs($spl->deriv(5.5)-237.669424604497) < 1e-6, 'deriv 5.5'  );
 ok(abs($spl->deriv2(5.5)-306.23332503967) < 1e-6, 'deriv2 5.5' );
 ok(abs($spl->integ(3.2,8.5)-4925.23555581654) < 1e-6, 'integ 3.2 to 8.5' );   
-ok(abs($spl->eval(5.5,{Extrapolate => 1})-237.641810667697) < 1e-6, 'eval 5.5 w Extrapolate' );
-ok(abs($spl->deriv(5.5,{Extrapolate => 1})-237.669424604497) < 1e-6, 'deriv 5.5 w Extrapolate' );
-ok(abs($spl->deriv2(5.5,{Extrapolate => 1})-306.23332503967) < 1e-6, 'deriv2 5.5 w Extrapolate' );
-ok(abs($spl->integ(3.2,8.5,{Extrapolate => 1})-4925.23555581654) < 1e-6, 'integ 3.2 to 8.5 w Extrapolate' );   
+eval { $spl->eval(10)     }; like($@,qr/input domain error/, 'eval 10 (extrapolation not allowed)') ;
+eval { $spl->deriv(10)    }; like($@,qr/input domain error/, 'deriv 10 (extrapolation not allowed)' );
+eval { $spl->deriv2(10)   }; like($@,qr/input domain error/, 'deriv2 10 (extrapolation not allowed)');
+eval { $spl->integ(8.5,10)}; like($@,qr/input domain error/, 'integ 8.5 to 10 (extrapolation not allowed)');
 
 # Bad value test added 5/31/2005 D. Hunt
 


### PR DESCRIPTION
Extrapolation seems to have been accidentally allowed by the
GSL interpolation routines. Since GSL v1.15 (released in 2011),
extrapolation returned NaN instead of extrapolating.  These changes
cause the interpolation routines to return an 'input domain error'
if the user attempts to extrapolate.

This should close #279.