### PR TITLE
use CCCDLFLAGS for compile of pdl.c to include -fPIC

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -389,7 +389,7 @@ my @podpms = map { $_.".pod", '$(INST_LIBDIR)/PDL/' . $_ .".pod"}
 my @prereq = (
 	   'Astro::FITS::Header' => 0,
            'Carp'                => 0,         # Need to run
-           'Config'              => 0,         # 
+           'Config'              => 0,         #
            'Convert::UU'         => 0,         # for PDL::IO::Dumper
            'Data::Dumper'        => 2.121,     # for PDL::IO::Dumper
            'English'             => 0,
@@ -597,7 +597,7 @@ EOPS
 # support the `$<` variable in explicit rules
 $text .= <<EOT if $^O !~ /MSWin/;
 pdl$Config::Config{exe_ext} : pdl.c
-	\$(CC) \$(CFLAGS) \$(LDFLAGS) \$(CPPFLAGS) pdl.c -o \$\@
+	\$(CC) \$(CFLAGS) \$(LDFLAGS) \$(CCCDLFLAGS) pdl.c -o \$\@
 EOT
 
 $text .= << 'EOT' if $^O =~ /MSWin/;


### PR DESCRIPTION
This addresses #285 and fixes build problems seen on both Centos8 with gcc8.3.1 and Fedora32 with gcc 10.2.1, where the final compilation of `pdl` from `pdl.c` fails because the `-fPIC` flag is not in the compile/link command. 

Although comments in the discussion at #285 suggests that this is somehow specific to Centos or Fedora, I very much doubt that to be the case, and suspect it is only due to versions of gcc.    The `Makefile.PL` in current master branch uses

    $(CC) $(CFLAGS) $(LDFLAGS) $(CPPFLAGS) pdl.c -o $@
 
to build `pdl`, but NEITHER (!!) `CFLAGS` nor `CPPFLAGS` is defined in Makefile.PL or Makefile.   `CCFLAGS` is defined, but is rather long and unneeded.  

This fix works to compile and pass tests of Fedora32 and Centos8.  But, again, I believe this is due to the version of gcc, not the flavor of Linux.