### PR TITLE
Fix spelling errors.

### DIFF
--- a/Basic/Slices/slices.pd
+++ b/Basic/Slices/slices.pd
@@ -1144,7 +1144,6 @@ EOD-RedoDims
               break;
             default:
               barf("Unknown boundary condition in range -- bug alert!");
-              /* Note clever misspelling of boundary to distinguish from other case */
               break;
           }
       }

--- a/Basic/Slices/slices.pd
+++ b/Basic/Slices/slices.pd
@@ -1143,7 +1143,7 @@ EOD-RedoDims
               ck = 0;
               break;
             default:
-              barf("Unknown boudnary condition in range -- bug alert!");
+              barf("Unknown boundary condition in range -- bug alert!");
               /* Note clever misspelling of boundary to distinguish from other case */
               break;
           }

--- a/IO/HDF/VS/VS.pd
+++ b/IO/HDF/VS/VS.pd
@@ -13,7 +13,7 @@ PDL::IO::HDF - An interface library for HDF4 files.
 
 =head1 DESCRIPTION
 
-This librairy provide functions to manipulate
+This library provide functions to manipulate
 HDF4 files with VS and V interface (reading, writing, ...)
 
 For more information on HDF4, see http://www.hdfgroup.org/products/hdf4/


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for the Debian package build:

 * boudnary -> boundary
 * librairy -> library