### PR TITLE
rfits properly treats BLANK in rice-compressed images with no BSCALE

### DIFF
--- a/IO/FITS/FITS.pm
+++ b/IO/FITS/FITS.pm
@@ -1609,6 +1609,8 @@ FITS standard, by adding an option hash to the arguments:
 
 =item compress 
 
+CURRENTLY UNIMPLEMENTED.  Below describes the envisioned usage.
+
 This can be either unity, in which case Rice compression is used,
 or a (case-insensitive) string matching the CFITSIO compression 
 type names.  Currently supported compression algorithms are:

--- a/IO/FITS/FITS.pm
+++ b/IO/FITS/FITS.pm
@@ -1538,7 +1538,7 @@ sub _rfits_unpack_zimage($$$) {
 	    );
     }
 
-    if(exists $hdr->{BSCALE}) {
+    if(exists $hdr->{BSCALE} || exists $hdr->{BLANK}) {
 	$pdl = treat_bscale($pdl, $hdr);
     }
     $pdl->sethdr($hdr);


### PR DESCRIPTION
As identified in issue #288, if a Rice-compressed image had a BLANK
keyword in the FITS header, that would not properly get set to BAD
if the FITS header did not also contain the BSCALE keyword.  This
was because treat_bscale(), which also deals with the BLANKs, was
not called if there was no BSCALE present.

Ideally this change would have a corresponding test, but without
compression in wfits, I don't see how to do it simply.