### PR TITLE
Avoid some compilation errors in GSL modules

### DIFF
--- a/Lib/GSL/DIFF/gsl_diff.pd
+++ b/Lib/GSL/DIFF/gsl_diff.pd
@@ -103,7 +103,7 @@ pp_addhdr('
 #include<stdio.h>
 #include<gsl/gsl_math.h>
 #include<gsl/gsl_diff.h>
-
+#include <gsl/gsl_errno.h>
 #include "FUNC.c"
 
 ');

--- a/Lib/GSL/SF/gslerr.h
+++ b/Lib/GSL/SF/gslerr.h
@@ -1,4 +1,4 @@
-
+#include <gsl/gsl_errno.h>
 static int status;
 static char buf[200];
 


### PR DESCRIPTION
I had the compiler error "implicit declaration of function 'gsl_set_error_handler_off' is invalid in C99"
because we weren't #including gsl_errno.h in some files.  Not sure
why these weren't showing up before!