### PR TITLE
Doc complex

### DIFF
--- a/Basic/Complex/complex.pd
+++ b/Basic/Complex/complex.pd
@@ -48,6 +48,19 @@ just treat the piddle as a real-valued piddle with a lowest dimension of
 size 2, so C<max> will return the maximum of all real and imaginary parts,
 not the "highest" (for some definition)
 
+=head2 Native complex support
+
+2.027 added changes in complex number handling, with support for C99
+complex floating-point types, and most functions and modules in the core
+distribution support these as well.
+
+PDL can now handle complex numbers natively as scalars. This has
+the advantage that real and complex valued piddles have the same
+dimensions. Consider this when writing code in the future.
+
+See L<PDL::Ops/ci>, L<PDL::Ops/creal>, L<PDL::Ops/cimag>,
+L<PDL::Ops/cabs>, L<PDL::Ops/carg>, L<PDL::Ops/conj> for more.
+
 =head1 TIPS, TRICKS & CAVEATS
 
 =over 4

--- a/Basic/Core/Core.pm
+++ b/Basic/Core/Core.pm
@@ -2823,6 +2823,14 @@ Convert to float datatype
 
 Convert to double datatype
 
+=head2 cfloat
+
+Convert to complex float datatype
+
+=head2 double
+
+Convert to complex double datatype
+
 =head2 type
 
 =for ref

--- a/Basic/PDL.pm
+++ b/Basic/PDL.pm
@@ -81,6 +81,12 @@ cannot find what you are looking for, try here.
 
 =back
 
+=head1 DATA TYPES
+
+PDL comes with support for most native numeric data types available in C.
+2.027 added support for C99 complex numbers.  See L<PDL::Complex>,
+L<PDL::Core>, L<PDL::Ops> and L<PDL::Math> for details on usage and
+behaviour.
 
 =head1 MODULES
 

--- a/Basic/Pod/PP.pod
+++ b/Basic/Pod/PP.pod
@@ -2027,8 +2027,8 @@ Only used if C<HandleBad =E<gt> 1>.
 =item GenericTypes
 
 An array reference. The array may contain any subset of the one-character
-strings `B', `S', `U', `L', `Q', `F' and `D', which specify which types
-your operation will accept. The meaning of each type is:
+strings given below, which specify which types your operation will
+accept. The meaning of each type is:
 
  B - signed byte (i.e. signed char)
  S - signed short (two-byte integer)
@@ -2038,9 +2038,11 @@ your operation will accept. The meaning of each type is:
  Q - signed long long (eight byte integer)
  F - float
  D - double
+ G - complex float
+ C - complex double
 
 This is very useful (and important!) when interfacing an external library.
-Default: [qw/B S U L N Q F D/]
+Default: [qw/B S U L N Q F D C G/]
 
 =item Inplace
 

--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+- native complex documented better - thanks @fantasma13
+
 2.032 2021-03-24
 - fix t/pptest.t so it passes on 5.10, add VERSION_FROM to pdlpp_stdargs
 


### PR DESCRIPTION
I've added a few snippets of documentation in several places. The two commits can be treated as one. 

There are still fundamental design decisions to be made, I think.
- creal, cimag, cabs, carg should cast onto float/double.
- comparison of complex numbers should fail.
In my opinion.