### PR TITLE
Remove PDL_clean_namespace and PDL_OLD_API defines

### DIFF
--- a/Basic/Core/pdlcore.h.PL
+++ b/Basic/Core/pdlcore.h.PL
@@ -258,15 +258,15 @@ void pdl_axisvals( pdl* a, int axis );               /* Fill with axis values */
 
 /* Structure to hold pointers core PDL routines so as to be used by many modules */
 
+#if defined(PDL_clean_namespace) || defined(PDL_OLD_API)
+#error PDL_clean_namespace and PDL_OLD_API defines have been removed. Use PDL->pdlnew() instead of PDL->new().
+#endif
+
 struct Core {
     I32    Version;
     pdl*   (*SvPDLV)      ( SV*  );
     void   (*SetSV_PDL)   ( SV *sv, pdl *it );
-#if defined(PDL_clean_namespace) || defined(PDL_OLD_API)
-    pdl*   (*new)      ( );     /* make it work with gimp-perl */
-#else
-    pdl*   (*pdlnew)      ( );  /* renamed because of C++ clash */
-#endif
+    pdl*   (*pdlnew)      ( );
     pdl*   (*tmp)         ( );
     pdl*   (*create)      (int type);
     void   (*destroy)     (pdl *it);

--- a/Basic/Pod/Internals.pod
+++ b/Basic/Pod/Internals.pod
@@ -536,11 +536,7 @@ F<pdlcore.h.PL> in F<Basic/Core>) and looks something like
     I32    Version;
     pdl*   (*SvPDLV)      ( SV*  );
     void   (*SetSV_PDL)   ( SV *sv, pdl *it );
- #if defined(PDL_clean_namespace) || defined(PDL_OLD_API)
-    pdl*   (*new)      ( );     /* make it work with gimp-perl */
- #else
-    pdl*   (*pdlnew)      ( );  /* renamed because of C++ clash */
- #endif
+    pdl*   (*pdlnew)      ( );
     pdl*   (*tmp)         ( );
     pdl*   (*create)      (int type);
     void   (*destroy)     (pdl *it);


### PR DESCRIPTION
The use of the old PDL API was added in 2002 specifically to backport a
fix for Gimp-Perl <https://github.com/PDLPorters/pdl/commit/cd83ceb6620e36c48b337f2675e7f5048c62e6eb>
so that it could continue to use `PDL->new()` instead of
`PDL->pdlnew()` in the C API.

This makes using that old API an error.

As far as I can tell, Gimp-Perl is the only user of this API. There is
an associated merge request at <https://gitlab.gnome.org/GNOME/gimp-perl/-/merge_requests/1>
which updates Gimp-Perl to the new API.

