### PR TITLE
CI: only run Cygwin build on tag creation (at release time)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,8 @@ jobs:
       PERL_MM_OPT: INSTALL_BASE=/cygdrive/c/cx
       CYGWIN_NOWINPATH: 1
     runs-on: windows-latest
-    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
+    # only run on tag because cygwin is slow
+    if: ${{ github.event_name == 'create' && github.event.ref_type == 'tag' }}
     needs: notify
     strategy:
       fail-fast: false
@@ -257,7 +258,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     if: ${{ ( github.event_name == 'push' || github.event_name == 'pull_request' ) && ( success() || failure() ) && github.repository == 'PDLPorters/pdl' }}
-    needs: [ 'ci', 'ci-ubuntu-containers', 'cygwin' ]
+    needs: [ 'ci', 'ci-ubuntu-containers' ]
     env:
       IRC_CHANNEL: '#pdl'
       IRC_SERVER: 'irc.perl.org'


### PR DESCRIPTION
Cygwin CI builds run slowly at the moment and it is not necessary to run
tests on Cygwin for every commit. This will still help catch problems
while not interfering with other builds.
