### PR TITLE
Use ignore case for testing inf()/nan()

### DIFF
--- a/t/core.t
+++ b/t/core.t
@@ -414,7 +414,7 @@ for (['ones', 1], ['zeroes', 0], ['nan', 'NaN'], ['inf', 'Inf']) {
   no strict 'refs';
   my $g = eval { $name->() };
   is $@, '', "$name works with no args";
-  is $g.'', $val, "$name() gives back right value";
+  like $g.'', qr/^\Q$val\E$/i, "$name() gives back right value";
   my $g1 = eval { $name->(2) };
   is $@, '', "$name works with 1 args";
   is_deeply [$g1->dims], [2], 'right dims';


### PR DESCRIPTION
Inf and NaN do not always stringify to the same capitalization on all
versions of Perl (newer versions of Perl do use "Inf" and "NaN"). In
fact, using the C standard library's formatting functions, both would be
in all lower-case:

```c
printf("%f %f\n", INFINITY, NAN); /* C output is "inf nan" */
```
