### PR TITLE
GHA: Restore cygwin job to build status pre-reqs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,9 +276,11 @@ jobs:
       IRC_PORT: '6667'
       IRC_NICKNAME: 'pdl-commits'
     steps:
+      - uses: actions/checkout@v2
       - name: Prepare message
         run: |
           echo "GITHUB_WORKFLOW_URL=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_ENV
+          echo "commitmsg="$( git show -s --oneline ${{ join(github.event.commits[0].id, ' ') }} ) >> $GITHUB_ENV
       - name: IRC build success
         uses: Gottox/irc-message-action@v1.3
         if: ${{ ! contains(needs.*.result, 'failure') && ! contains(needs.*.result, 'cancelled') }}
@@ -291,7 +293,7 @@ jobs:
           notice: true
           message: |
             Build status: All builds succeeded [${{ github.event_name }}]: ${{ env.GITHUB_WORKFLOW_URL }}
-            @ ${{ github.sha }} | ${{ github.event.commits[0].author.name }} | «${{ github.event.commits[0].message }}»
+            @ ${{ github.sha }} | ${{ github.event.commits[0].author.name }} | «${{ env.commitmsg }}»
       - name: IRC build failure
         uses: Gottox/irc-message-action@v1.3
         if: ${{ contains(needs.*.result, 'failure') }}
@@ -304,4 +306,4 @@ jobs:
           notice: true
           message: |
             Build status: Some builds failed [${{ github.event_name }}]: ${{ env.GITHUB_WORKFLOW_URL }}
-            @ ${{ github.sha }} | ${{ github.event.commits[0].author.name }} | «${{ github.event.commits[0].message }}»
+            @ ${{ github.sha }} | ${{ github.event.commits[0].author.name }} | «${{ env.commitmsg }}»

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,8 +268,8 @@ jobs:
   build-status:
     runs-on: ubuntu-latest
     continue-on-error: true
-    if: ${{ ( github.event_name == 'push' || github.event_name == 'pull_request' ) && ( success() || failure() ) && github.repository == 'PDLPorters/pdl' }}
-    needs: [ 'ci', 'ci-ubuntu-containers' ]
+    if: ${{ ( github.event_name == 'push' || github.event_name == 'pull_request' || ( github.event_name == 'create' && github.event.ref_type == 'tag' ) ) && ( always() ) && github.repository == 'PDLPorters/pdl' }}
+    needs: [ 'ci', 'ci-ubuntu-containers', 'cygwin' ]
     env:
       IRC_CHANNEL: '#pdl'
       IRC_SERVER: 'irc.perl.org'


### PR DESCRIPTION
By adding the tag event as a condition to get the build status
for all jobs.
