### PR TITLE
GHA: Add step to run make disttest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
             os: ubuntu-latest
             release-test: true
             coverage: true
+            disttest: true
           - perl-version: '5.30'
             os: ubuntu-latest
             eumm-blead: 1
@@ -95,6 +96,12 @@ jobs:
         with:
           target-test: true
           test-enable-coverage: ${{ matrix.coverage }}
+
+      - name: 'disttest'
+        if: matrix.disttest
+        run: |
+          set -e
+          ( [ -f Makefile ] || $MYPERL Makefile.PL ) && make disttest
 
       - name: Run tests after install (no coverage)
         if: '!matrix.coverage && matrix.test-installed'


### PR DESCRIPTION
Adding per discussion in IRC.

This is to address the issue that led to the fix in <https://github.com/pdLPorters/pdl/commit/b8e8f04a1aa4a89a31b1389c351affb3b992f1c0>.

This may be useful in other PDLPorters repos and can be extracted as a target
at a later time.

[Testing the expected build failure](https://github.com/PDLPorters/pdl/runs/3694829628?check_suite_focus=true) by running this change on top of the commit prior to the fix mentioned above:

![Screenshot 2021-09-23 at 21-30-19 Build software better, together](https://user-images.githubusercontent.com/94489/134605165-87ec9261-e60f-423d-b84c-0640de78b188.png)

