### PR TITLE
minor speedups for _establish_type

### DIFF
--- a/Basic/Core/Core.pm
+++ b/Basic/Core/Core.pm
@@ -1157,7 +1157,7 @@ sub PDL::new {
        }
        $value = ($PDL::undefval//0)+0
    }
-   $type = _establish_type($value, $PDL_D) if !defined $type;
+   $type //= ref($value) ? _establish_type($value, $PDL_D) : $PDL_D;
 
    return pdl_avref($value,$this,$type) if ref($value) eq "ARRAY";
    my $new = $this->initialize();

--- a/Basic/Core/Core.pm
+++ b/Basic/Core/Core.pm
@@ -1142,7 +1142,9 @@ sub _establish_type {
   return $PDL_CD if UNIVERSAL::isa($item, 'Math::Complex');
   return max($item->type->enum, $sofar) if UNIVERSAL::isa($item, 'PDL');
   return $PDL_D if ref($item) ne 'ARRAY';
-  max($sofar, map _establish_type($_, $sofar), @$item);
+  #  only need to recurse for items that are refs
+  #  as $sofar will be $PDL_D at a minimum
+  max ($sofar, map {_establish_type($_, $sofar)} grep {ref} @$item);
 }
 
 sub PDL::new {


### PR DESCRIPTION
When a scalar variable is not a ref then there is no need to call _establish_type to only get the default value back, particularly where this will always be <= the type found so far.

Passes all tests but perhaps there are some edge cases lurking.  
