### PR TITLE
Test that $PDL::Core::VERSION matches $PDL::VERSION when first set

### DIFF
--- a/Basic/Core/Core.pm
+++ b/Basic/Core/Core.pm
@@ -8,7 +8,7 @@ use PDL::Exporter;
 require PDL; # for $VERSION
 use DynaLoader;
 our @ISA    = qw( PDL::Exporter DynaLoader );
-our $VERSION = '2.028'; # PAUSE insists - below is the real one
+our $VERSION = '2.060'; # PAUSE insists - below is the real one
 $VERSION = $PDL::VERSION;
 bootstrap PDL::Core $VERSION;
 use PDL::Types ':All';

--- a/MANIFEST
+++ b/MANIFEST
@@ -716,6 +716,7 @@ Perldl2/TODO
 README
 t/00-report-prereqs.t
 t/01-pptest.t
+t/02-pdl-core-version.t
 t/autoload.t
 t/bad.t
 t/basic.t

--- a/t/02-pdl-core-version.t
+++ b/t/02-pdl-core-version.t
@@ -1,0 +1,22 @@
+#  logic adapted from 00-report-prereqs.t
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use ExtUtils::MakeMaker;
+use File::Spec;
+use PDL;
+
+my $file = 'PDL::Core';
+$file =~ s{::}{/}g;
+$file .= ".pm";
+my ($prefix) = grep { -e File::Spec->catfile($_, $file) } @INC;
+
+my $filename         = File::Spec->catfile($prefix, $file);
+my $pdl_core_version = MM->parse_version( $filename );
+
+is $pdl_core_version, $PDL::VERSION, 'versions match: PDL and PDL::Core';
+
+done_testing;


### PR DESCRIPTION
This will help avoid red herrings in prereq reporting tests
such as https://www.cpantesters.org/cpan/report/b610a1c0-6bf7-1014-a048-271994176946
where PDL::Core is reported as 2.028 instead of 2.057.

Possibly should be an author test under the xt dir.  

Could also be extended to other files with hard coded versions if a common version is deemed useful, but PDL::Core seems to be the only file that updates its version after it is initially set.

