### PR TITLE
Use File::Which to find executables

### DIFF
--- a/Changes
+++ b/Changes
@@ -17,6 +17,7 @@
 - IO::Pic::rmpeg added
 - IO::Pic::rpic will return an n+1-dim ndarray if multiple images in file
 - set_datatype (and PDL.converttype) now badval-aware
+- add dependency on File::Which
 
 2.063_03 2021-11-23
 - add pp_add_macros

--- a/IO/FlexRaw/t/flexraw_fortran.t
+++ b/IO/FlexRaw/t/flexraw_fortran.t
@@ -5,6 +5,7 @@ use Config;
 use Test::More;
 use File::Temp qw(tempfile);
 use File::Spec;
+use File::Which ();
 
 my $prog_iter;
 
@@ -140,14 +141,6 @@ sub codefold {
 
    $newcode = $oldcode if $@;
    return $newcode;
-}
-
-sub inpath {
-  my ($prog) = @_;
-  my $pathsep = $^O =~ /win32/i ? ';' : ':';
-  my $exe = $^O =~ /win32/i ? '.exe' : '';
-  for (split $pathsep, $ENV{PATH}) { return 1 if -x "$_/$prog$exe" }
-  return 0;
 }
 
 # createData $head, $code
@@ -538,11 +531,11 @@ foreach (@req) {
 ok( $ok, "readflex combined types" );
 
 SKIP: {
-   my $compress = inpath('compress') ? 'compress' : 'gzip'; # some linuxes don't have compress
+   my $compress = File::Which::which('compress') ? 'compress' : 'gzip'; # some linuxes don't have compress
    $compress = 'gzip' if $^O eq 'cygwin';                   # fix bogus compress script prob
 
    if ( $^O eq 'MSWin32' ) {    # fix for ASPerl + MinGW, needs to be more general
-      skip "No compress or gzip command on MSWin32", 1 unless inpath($compress) and $^O;
+      skip "No compress or gzip command on MSWin32", 1 unless File::Which::which($compress) and $^O;
    }
 
 # Try compressed data

--- a/IO/t/dumper.t
+++ b/IO/t/dumper.t
@@ -1,18 +1,11 @@
 use strict;
 use Test::More;
 use Config;
-
-sub inpath {
-  my ($prog) = @_;
-  for ( split $Config{path_sep}, $ENV{PATH} ) {
-    return 1 if -x "$_/$prog$Config{exe_ext}"
-  }
-  return;
-}
+use File::Which ();
 
 BEGIN {
    eval "use Convert::UU;";
-   my $hasuuencode = !$@ || (inpath('uuencode') && inpath('uudecode'));
+   my $hasuuencode = !$@ || (File::Which::which('uuencode') && File::Which::which('uudecode'));
 
    if ($hasuuencode) {
       plan tests => 17;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -123,6 +123,7 @@ my @cpan_deps = my @prereq = (
   'Convert::UU'         => 0,         # for PDL::IO::Dumper
   'Data::Dumper'        => 2.121,     # for PDL::IO::Dumper
   'File::Map'           => 0.57,      # test new mmap implementation
+  'File::Which'         => 0,
   'Filter::Util::Call'  => 0,         # for PDL::NiceSlice
   'Filter::Simple'      => 0.88,      # for new PDL::NiceSlice
   'List::Util'          => '1.33',


### PR DESCRIPTION
`File::Which::which()` replaces the ad hoc `inpath()` functions.
