### PR TITLE
Fix POD errors.

### DIFF
--- a/Graphics/PGPLOT/Window/Window.pm
+++ b/Graphics/PGPLOT/Window/Window.pm
@@ -1413,7 +1413,7 @@ Turn on automatic logarithmic scaling in C<line> and C<points>
 Setting the argument to 1 turns on automatic log scaling and setting it to
 zero turns it off again. The function can be used in both the object
 oriented and standard interface. To learn more, see the documentation for
-the L</axis option|axis>.
+the L<axis option|/axis>.
 
 =for example
 


### PR DESCRIPTION
The lintian QA tool reported a POD error for the Debian package build:
```
 Around line 1413:
  alternative text '/axis option' contains non-escaped | or /
```