### PR TITLE
Improve version parsing in some GSL modules

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+- improve GSL version parsing - thanks @d-lamb
+
 2.068_02 2022-01-17
 - Slatec 64-bit safe
 

--- a/Libtmp/GSL/SF/ellint/gsl_sf_ellint.pd
+++ b/Libtmp/GSL/SF/ellint/gsl_sf_ellint.pd
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use version;
 
 pp_addpm({At=>'Top'},<<'EOD');
 use strict;
@@ -84,9 +85,9 @@ $e() = r.err;
        Doc =>'Legendre form of incomplete elliptic integrals P(phi,k,n) = Integral[(1 + n Sin[t]^2)^(-1)/Sqrt[1 - k^2 Sin[t]^2], {t, 0, phi}]'
       );
 
-my $v = `gsl-config --version`;
+chomp(my $v = `gsl-config --version`);
 
-if($v < 2.0) {
+if(version->parse($v) < version->parse(2.0)) {
 
 pp_def('gsl_sf_ellint_D',
        GenericTypes => ['D'],

--- a/Libtmp/GSL/SF/legendre/gsl_sf_legendre.pd
+++ b/Libtmp/GSL/SF/legendre/gsl_sf_legendre.pd
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use version;
 
 pp_addpm({At=>'Top'},<<'EOD');
 use strict;
@@ -72,8 +73,8 @@ $e() = r.err;
        Doc =>'P_lm(x)'
       );
 
-my $v = `gsl-config --version`;
-if (defined($v) && $v>=2.0){
+chomp(my $v = `gsl-config --version`);
+if (defined($v) && version->parse($v)>=version->parse(2.0)){
 
     pp_def('gsl_sf_legendre_array',
 	   GenericTypes => ['D'],
@@ -198,7 +199,7 @@ Note that this function is called differently than the corresponding GSL functio
 	);
 
 
-} elsif (defined($v) && $v<2.0) {
+} elsif (defined($v) && version->parse($v)<version->parse(2.0)) {
 
 pp_def('gsl_sf_legendre_Plm_array',
        GenericTypes => ['D'],


### PR DESCRIPTION
When `gsl-config --version` returns a dotted triple like '2.7.1',
simple parsing like `$version <2.0` does not work.