### PR TITLE
Add complex support to interpolate(), fixes #408

### DIFF
--- a/Basic/Primitive/primitive.pd
+++ b/Basic/Primitive/primitive.pd
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use PDL::Types qw(ppdefs_all types);
 my $F = [map $_->ppsym, grep $_->real && !$_->integer, types()];
+my $AF = [map $_->ppsym, grep !$_->integer, types];
 
 pp_addpm({At=>'Top'},<<'EOD');
 use strict;
@@ -2962,8 +2963,17 @@ for my $func ( [
 pp_def('interpolate',
        HandleBad => 0,
        BadDoc => 'needs major (?) work to handles bad values',
-	Pars => 'xi(); x(n); y(n); [o] yi(); int [o] err()',
-	GenericTypes => $F, # too restrictive ?
+	Pars => 'real xi(); real x(n); y(n); [o] yi(); int [o] err()',
+	GenericTypes => $AF,
+	PMCode => 'sub PDL::interpolate {
+			my ($xi, $x, $y, $yi, $err) = @_;
+			croak "x must be real" if (ref($x) && ! $x->type->real);
+			croak "xi must be real" if (ref($xi) && ! $xi->type->real);
+			$yi //= PDL->null;
+			$err //= PDL->null;
+			PDL::_interpolate_int($xi, $x, $y, $yi, $err);
+			($yi, $err);
+		}',
 	Code => '
 		 $GENERIC() d;
 		 PDL_Indx n  = $SIZE(n);
@@ -3025,6 +3035,9 @@ which is otherwise 0.
 See also L</interpol>, which uses the same routine,
 differing only in the handling of extrapolation - an error message
 is printed rather than returning an error ndarray.
+
+Note that C<interpolate> can use complex values for C<$y> and C<$yi> but
+C<$x> and C<$xi> must be real.
 
 =cut
 

--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@
 - change PP-generated XS PROTOTYPES to DISABLE
 - allow [o] on OtherPars (#362)
 - fix conv2d to allow complex arguments (#407) - thanks @wlmb
+- Add complex support to interpolate (#408) - thanks @KJ7LNW
 
 2.080 2022-05-28
 - make IO::STL work on big-endian systems (#394) - thanks @sebastic for report

--- a/t/primitive.t
+++ b/t/primitive.t
@@ -423,7 +423,15 @@ ok(all( $z==pdl(0,0,0,0,1,4,4) ), "one2nd z");
 my $yvalues =  (new PDL( 0..5))   - 20;
 my $xvalues = -(new PDL (0..5))*.5;
 my $x = new PDL(-2);
-is( $x->interpol($xvalues,$yvalues), -16 );
+is( $x->interpol($xvalues,$yvalues), -16, "interpolate: real-valued" );
+}
+
+{
+my $yvalues =  ((new PDL( 0..5))   - 20) * (1+i()) ;
+my $xvalues = -(new PDL (0..5))*.5;
+my $x = new PDL(-2);
+is( $x->interpol($xvalues,$yvalues), -16 - 16*i, "interpolate: complex-valued" );
+ok( !eval { $x->interpol($xvalues*i(),$yvalues) } , "interpolate: x must be real" );
 }
 
 # Some of these tests are based upon those in Chapter 5 of Programming


### PR DESCRIPTION
This fixes #408.  Not sure if this is the "right" way to fix this, so please review:

About types signatures and `complex`, [PDL::PP](https://metacpan.org/pod/PDL::PP) says _"...If the operation is already complex, there is no effect; if not, the output will be promoted to the type's ["complexversion" in PDL::Type](https://metacpan.org/pod/PDL::Type#complexversion), which defaults to cfloat. Note this is controlled both by the [PDL::Types](https://metacpan.org/pod/PDL::Types) data, and the code in [PDL::PP](https://metacpan.org/pod/distribution/PDL/Basic/Pod/PP.pod)."_

What does _"will be promoted to the type's ["complexversion"](https://metacpan.org/pod/PDL::Type#complexversion)"_ mean?

So if `$y` is complex then `$yi` will be too...but if the caller passes `$y` as real then I would think `interpolate()` should return `$yi` as real, too.  Would it?