### PR TITLE
Refactor curses detection to use ncurses*-config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         uses: PDLPorters/devops/github-actions/ci-dist@master
         with:
           target-install-dist-perl-deps: true
-          dist-perl-deps-configure: ExtUtils::MakeMaker Devel::CheckLib
+          dist-perl-deps-configure: ExtUtils::MakeMaker Devel::CheckLib File::Which
 
       - name: 'ci-dist: target-test-release-testing'
         uses: PDLPorters/devops/github-actions/ci-dist@master
@@ -142,7 +142,7 @@ jobs:
           uname -a
           yum -y install perl perl-App-cpanminus gcc bzip2 patch
       - run: perl -V
-      - run: cpanm -n ExtUtils::MakeMaker Devel::CheckLib && cpanm -n --installdeps . || cat ~/.cpanm/build.log
+      - run: cpanm -n ExtUtils::MakeMaker Devel::CheckLib File::Which && cpanm -n --installdeps . || cat ~/.cpanm/build.log
       - name: Run tests
         env:
           HARNESS_OPTIONS: j4
@@ -209,7 +209,7 @@ jobs:
         run: |
           export PATH="/cygdrive/c/cx/bin:$PATH"
           cd $( cygpath -u $GITHUB_WORKSPACE )
-          cpanm -n Devel::CheckLib && cpanm -n --installdeps . || cat ~/.cpanm/build.log
+          cpanm -n Devel::CheckLib File::Which && cpanm -n --installdeps . || cat ~/.cpanm/build.log
       - name: Run tests (no coverage)
         env:
           HARNESS_OPTIONS: j4

--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@
 - fix conv2d to allow complex arguments (#407) - thanks @wlmb
 - Add complex support to interpolate (#408) - thanks @KJ7LNW
 - Refactor PDL::IO::Browser curses detection to additionally use ncurses*-config (#412)
+- Add File::Which as a configure dependency (previously runtime only) (#412)
 
 2.080 2022-05-28
 - make IO::STL work on big-endian systems (#394) - thanks @sebastic for report

--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@
 - allow [o] on OtherPars (#362)
 - fix conv2d to allow complex arguments (#407) - thanks @wlmb
 - Add complex support to interpolate (#408) - thanks @KJ7LNW
+- Refactor PDL::IO::Browser curses detection to additionally use ncurses*-config (#412)
 
 2.080 2022-05-28
 - make IO::STL work on big-endian systems (#394) - thanks @sebastic for report

--- a/IO/Browser/Makefile.PL
+++ b/IO/Browser/Makefile.PL
@@ -3,6 +3,7 @@ use warnings;
 use ExtUtils::MakeMaker;
 use File::Spec;
 eval { require Devel::CheckLib; Devel::CheckLib->import; };
+eval { require File::Which; };
 
 my @pack = (["browser.pd", qw(Browser PDL::IO::Browser)]);
 
@@ -38,6 +39,9 @@ foreach my $incl (@possible_headers) {
 
 sub conf_via_ncurses_config {
    return () unless $found_header;
+   # NOTE the ncurses*-config executables are shell scripts so `sh` is
+   # required.
+   return () unless File::Which::which('sh');
 
    my @nc_configs = qw(
       ncurses6-config
@@ -47,6 +51,9 @@ sub conf_via_ncurses_config {
    );
    for my $nc_conf (@nc_configs) {
       local $ENV{NCURSES_CONFIG_PROG} = $nc_conf;
+      # NOTE which() can not find the script on Windows because it does have
+      # have a PATHEXT suffix. For now, just try to run it anyway.
+      next unless File::Which::which($nc_conf) || $^O eq 'MSWin32';
       if( eval { (my $version = _read_pipe(qw(sh -c), '$NCURSES_CONFIG_PROG --version')) =~ / \A [0-9.]+ \Z /x } ) {
          my $cflags = _read_pipe(qw(sh -c), '$NCURSES_CONFIG_PROG --cflags');
          my $libs   = _read_pipe(qw(sh -c), '$NCURSES_CONFIG_PROG --libs');

--- a/IO/Browser/Makefile.PL
+++ b/IO/Browser/Makefile.PL
@@ -20,29 +20,82 @@ $hash{'clean'}{FILES} .= ' browse$(OBJ_EXT) browse$(EXE_EXT) Browser.c Browser.p
 # (4) confirm configuration
 # (5) write Makefile or dummy as appropriate
 
-my $incstring;
-foreach my $incl ( qw( curses.h ncurses/curses.h ncurses.h ncurses/ncurses.h ncursesw/ncurses.h ) ) {
+sub _read_pipe {
+   my (@command) = @_;
+   open( my $fh, '-|', @command) or die "Unable to run @command: $!";
+   chomp(my $output = do { local $/; <$fh> });
+   $output;
+}
+
+my @possible_headers = qw( curses.h ncurses/curses.h ncurses.h ncurses/ncurses.h ncursesw/ncurses.h );
+my $found_header;
+foreach my $incl (@possible_headers) {
     if (eval { check_lib(header=>$incl) }) {
-       $incstring = $incl;
+       $found_header = $incl;
        last;
     }
-};
-$hash{DEFINE} .= ' -DCURSES=' . '\\"' . $incstring . '\\"' if defined $incstring;
-
-my $libstring;
-foreach my $libr ( qw( curses ncurses ncursesw ) ) {
-   if (eval { check_lib(lib=>$libr) }) {
-      $libstring = '-l' . $libr;
-      last;
-   }
 }
-push @{$hash{LIBS}} , $libstring if defined $libstring;
+
+sub conf_via_ncurses_config {
+   return () unless $found_header;
+
+   my @nc_configs = qw(
+      ncurses6-config
+      ncursesw6-config
+      ncurses5-config
+      ncursesw5-config
+   );
+   for my $nc_conf (@nc_configs) {
+      local $ENV{NCURSES_CONFIG_PROG} = $nc_conf;
+      if( eval { (my $version = _read_pipe(qw(sh -c), '$NCURSES_CONFIG_PROG --version')) =~ / \A [0-9.]+ \Z /x } ) {
+         my $cflags = _read_pipe(qw(sh -c), '$NCURSES_CONFIG_PROG --cflags');
+         my $libs   = _read_pipe(qw(sh -c), '$NCURSES_CONFIG_PROG --libs');
+         return (
+            header => $found_header,
+            inc    => $cflags,
+            libs   => $libs,
+         );
+      }
+   }
+   return ();
+}
+
+sub conf_via_checklib {
+   return () unless $found_header;
+
+   my $libstring;
+   foreach my $libr ( qw( curses ncurses ncursesw ) ) {
+      if (eval { check_lib(lib=>$libr) }) {
+         $libstring = '-l' . $libr;
+         last;
+      }
+   }
+
+   if( defined $libstring ) {
+      return (
+         header => $found_header,
+         inc    => '',
+         libs   => $libstring,
+      );
+   }
+
+   return ();
+}
+
+my %conf_data;
+%conf_data = conf_via_ncurses_config();
+%conf_data = conf_via_checklib() unless %conf_data;
+if( %conf_data ) {
+   $hash{DEFINE} .= ' -DCURSES=' . '\\"' . $conf_data{header} . '\\"';
+   $hash{INC} .= ' ' . $conf_data{inc} if $conf_data{inc};
+   push @{$hash{LIBS}} , $conf_data{libs};
+}
 
 # Add genpp rule
 undef &MY::postamble; # suppress warning
 *MY::postamble = sub { pdlpp_postamble_int(@pack); };
 
-if (defined($incstring) && defined($libstring)) {
+if ( %conf_data ) {
    WriteMakefile(%hash);
 } else {
    write_dummy_make("Curses capable library not found, not building PDL::IO::Browser");

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -174,6 +174,7 @@ my %makefile_hash = (
   LICENSE => 'perl',
   CONFIGURE_REQUIRES => {
     'Devel::CheckLib' => '1.01',
+    'File::Which'     => 0,
     'Carp'            => 1.20,    # EU::MM seems to need this not to crash
     'ExtUtils::MakeMaker' => '7.12', # working .g.c
     'File::Path'          => 0,


### PR DESCRIPTION
This helps on systems where additional libraries are needed in order to
link against `ncurses`. In particular, this is useful for MSYS2.
