### PR TITLE
Address clang compiler warnings in PDL 2.082

### DIFF
--- a/Basic/Ops/ops.pd
+++ b/Basic/Ops/ops.pd
@@ -408,7 +408,7 @@ cfunc('re', 'creal', 1, 'Returns the real part of a complex number.',
 cfunc('im', 'cimag', 1, 'Returns the imaginary part of a complex number.',
   '$complexv() = creal($complexv()) + I * $b();'
 );
-cfunc('_cabs', 'cabs', 1, 'Returns the absolute (length) of a complex number.', undef,
+cfunc('_cabs', 'fabs', 1, 'Returns the absolute (length) of a complex number.', undef,
     PMFunc=>'',
 );
 my $rabs_code = '


### PR DESCRIPTION
These commits address most, but not all, of the clang compiler warnings that I see with PDL 2.082.  Most have to do with the newly supported datatypes such as (complex) Long Double, and avoids possible truncation-of-value problems.