### PR TITLE
Test some operations with empty ndarrays.

### DIFF
--- a/Basic/Primitive/primitive.pd
+++ b/Basic/Primitive/primitive.pd
@@ -3691,8 +3691,8 @@ sub PDL::whereND :lvalue {
       # $mask = a b c d e f.....
       my @idims = dims($arr);
       splice @idims, 0, $maskndims; # pop off the number of dims in $mask
-      if (!$n) {
-        push @to_return, PDL->zeroes($arr->type, 0, @idims);
+      if (!$n or $arr->isempty) {
+        push @to_return, PDL->zeroes($arr->type, $n, @idims);
         next;
       }
       my $sub_i = $mask * ones($arr);

--- a/Changes
+++ b/Changes
@@ -18,7 +18,7 @@
 - OtherPars can now be $argname, for XS processing only and not in operation
 - fix broadcasting over empty ndarray (#429) - thanks @falsifian for tests
 - fix appending with empty ndarray (#430) - thanks @falsifian for tests
-- fix whereND with all-zero mask (#428) - thanks @falsifian for tests
+- fix whereND with all-zero mask or empty input (#428) - thanks @falsifian for tests
 
 2.082 2023-03-22
 - no changes from 2.081_03

--- a/t/primitive.t
+++ b/t/primitive.t
@@ -97,6 +97,8 @@ is random(1,1,0)->type, 'double'; # used to segfault
 is_deeply $got=[append(zeroes(2,0),zeroes(3,0))->dims], [5,0] or diag "got:", explain $got;
 is_deeply append(zeroes(float,2,0),zeroes(3,0))->type, 'float';
 is_deeply $got=[zeroes(2,3,1)->whereND(pdl '0 0')->dims], [0,3,1] or diag "got:", explain $got;
+eval {is_deeply [zeroes(2,0)->whereND(pdl '1 1')->dims], [2,0]};
+is $@, '', "zeroes(2,0)->whereND(pdl '1 1') works";
 
 ##############################
 # check that our random functions work with Perl's srand


### PR DESCRIPTION
The new tests all fail, two of them by segfaulting.

This covers GitHub issues #428, #429 and #430, and also an unreported issue that random(1,1,0) segfaults.