### PR TITLE
Fix builds on MacOS Ventura

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,8 @@
 - fix GIS::Proj to work better on Windows (#456) - thanks @shawnlaffan
 - fix conversion of ulonglong to Perl scalar and therefore stringification (#458) - thanks @vadim-160102 for report
 - fix modulo for ulonglong and on Windows
+- update Opt::Simplex docs (#452) - thanks @KJ7LNW
+- fix Graphics::OpenGLQ on MacOS Ventura (#452) - thanks @deriamis
 
 2.084 2023-05-21
 - reduce size of PDL_KLUDGE_COPY_X macro to <4096 in line with C standard, to fix for older clang on many BSD

--- a/Graphics/TriD/OpenGLQ/openglq.pd
+++ b/Graphics/TriD/OpenGLQ/openglq.pd
@@ -34,7 +34,7 @@ pp_addhdr('
 #ifdef HAVE_AGL_GLUT
 #include <OpenGL/gl.h>
 #include <OpenGL/glu.h>
-#include <OpenGL/glut.h>
+#include <GLUT/glut.h>
 #else
 #include <GL/gl.h>
 #include <GL/glu.h>


### PR DESCRIPTION
Apple has apparently changed the location of glut.h in recent versions of MacOS. This is a small change to get things building again on the platform.