### PR TITLE
GIS::Proj - Use Alien::proj

### DIFF
--- a/Libtmp/GIS/Proj/Proj.pd
+++ b/Libtmp/GIS/Proj/Proj.pd
@@ -16,6 +16,13 @@ use warnings;
 
 our $VERSION = "1.32";
 
+pp_addbegin (<<'EOAP');
+  use Alien::proj;
+  if ($^O =~ /MSWin32/ and $Alien::proj::VERSION le '1.25') {
+    $ENV{PATH} = join ';', (Alien::proj->bin_dirs, $ENV{PATH});
+  }
+EOAP
+
 pp_addpm({At=>'Top'},<<'EODOC');
 use strict;
 use warnings;


### PR DESCRIPTION
And add its bin dirs to the path on Windows
so it can function.

Done using pp_addbegin as pp_addpm happens
after the dynaload call, which is too late.

Updates #441