### PR TITLE
typemap handling

### DIFF
--- a/Basic/Gen/PP.pm
+++ b/Basic/Gen/PP.pm
@@ -1030,8 +1030,9 @@ sub typemap {
 }
 sub typemap_eval { # lifted from ExtUtils::ParseXS::Eval, ignoring eg $ALIAS
   my ($code, $varhash) = @_;
-  my ($var, $type, $num, $init, $printed_name, $arg, $ntype, $argoff, $subtype)
-    = @$varhash{qw(var type num init printed_name arg ntype argoff subtype)};
+  my ($var, $type, $num, $init, $pname, $arg, $ntype, $argoff, $subtype)
+    = @$varhash{qw(var type num init pname arg ntype argoff subtype)};
+  my $ALIAS;
   my $rv = eval qq("$code");
   die $@ if $@;
   $rv;
@@ -1078,9 +1079,10 @@ sub callPerlInit {
 }
 
 sub callTypemap {
-  my ($x, $ptype) = @_;
+  my ($x, $ptype, $pname) = @_;
   my ($setter, $type) = typemap($ptype, 'get_inputmap');
-  my $ret = typemap_eval($setter, {var=>$x, type=>$type, arg=>("${x}_SV")});
+  my $ret = typemap_eval($setter, {var=>$x, type=>$type, arg=>("${x}_SV"),
+      pname=>$pname});
   $ret =~ s/^\s*(.*?)\s*$/$1/g;
   $ret =~ s/\s*\n\s*/ /g;
   $ret;
@@ -1637,7 +1639,7 @@ EOD
           $name2cnts{$x} = [$cnt, undef];
           $name2cnts{$x}[1] = ++$shortcnt if !($out{$x} || $other_out{$x});
           push @xsargs, "$x=$x";
-          push @inputdecls, "$ptypes{$x}$x".($other{$x} && !exists $otherdefaults->{$x} ? "; { ".callTypemap($x, $ptypes{$x})."; }" : "=NO_INIT");
+          push @inputdecls, "$ptypes{$x}$x".($other{$x} && !exists $otherdefaults->{$x} ? "; { ".callTypemap($x, $ptypes{$x}, $name)."; }" : "=NO_INIT");
         }
         push @inputdecls, map "$ptypes{$_}$_=".callPerlInit($_."_SV", $callcopy).";", grep $outca{$_}, @args;
         my $defaults_rawcond = $ndefault ? "items == $nin_minus_default" : '';
@@ -1657,10 +1659,10 @@ EOD
           indent(2, join '',
             (map
               "if (!${_}_SV) { $_ = ($otherdefaults->{$_}); } else ".
-              "{ ".callTypemap($_, $ptypes{$_})."; }\n",
+              "{ ".callTypemap($_, $ptypes{$_}, $name)."; }\n",
               grep !$argorder && exists $otherdefaults->{$_}, @{$sig->othernames(1, 1)}),
-            (map callTypemap($_, $ptypes{$_}).";\n", grep !$already_read{$_}, $sig->names_in),
-            (map +("if (${_}_SV) { ".($argorder ? '' : callTypemap($_, $ptypes{$_}))."; } else ")."$_ = ".callPerlInit($_."_SV", $callcopy).";\n", grep $out{$_} && !$already_read{$_} && !($inplace && $_ eq $inplace->[1]), @args)
+            (map callTypemap($_, $ptypes{$_}, $name).";\n", grep !$already_read{$_}, $sig->names_in),
+            (map +("if (${_}_SV) { ".($argorder ? '' : callTypemap($_, $ptypes{$_}, $name))."; } else ")."$_ = ".callPerlInit($_."_SV", $callcopy).";\n", grep $out{$_} && !$already_read{$_} && !($inplace && $_ eq $inplace->[1]), @args)
           );
         push @preinit, qq[PDL_XS_PREAMBLE($nretval);] if $nallout;
         push @preinit, qq{if (!(@{[join ' || ', map "(items == $_)", sort keys %valid_itemcounts]}))
@@ -1708,7 +1710,8 @@ $preamble@{[join "\n  ", "", @inputdecls]}
         my %ptypes = map +($_=>$$optypes{$_}->get_decl('', {VarArrays2Ptrs=>1})), @other_output;
         for my $x (@other_output) {
           my ($setter, $type) = typemap($ptypes{$x}, 'get_outputmap');
-          $setter = typemap_eval($setter, {var=>$x, type=>$type, arg=>"tsv"});
+          $setter = typemap_eval($setter, {var=>$x, type=>$type, arg=>"tsv",
+              pname=>$name});
           $clause1 .= <<EOF;
 if (!${x}_SV)
   PDL->pdl_barf("Internal error in $name: tried to output to NULL ${x}_SV");

--- a/Basic/Gen/PP/PDLCode.pm
+++ b/Basic/Gen/PP/PDLCode.pm
@@ -24,6 +24,7 @@ sub new {
        $handlebad, $sig,$generictypes,$extrageneric,$havebroadcasting,$name,
        $dont_add_brcloop, $backcode, $nulldatacheck) = @_;
     my $parnames = $sig->names_sorted;
+    $handlebad = !!$handlebad;
 
     die "Error: missing name argument to PDL::PP::Code->new call!\n"
       unless defined $name;

--- a/Basic/Pod/PP.pod
+++ b/Basic/Pod/PP.pod
@@ -118,7 +118,6 @@ C<string>, or C<file>.
 =for example
 
   pp_add_typemaps(string=><<'EOT');
-  TYPEMAP: <<END_OF_TYPEMAP
   TYPEMAP
   NV_ADD1 T_NV_ADD1
 
@@ -129,7 +128,6 @@ C<string>, or C<file>.
   OUTPUT
   T_NV_ADD1
     sv_setnv($arg, $var - 1);
-  END_OF_TYPEMAP
   EOT
   # ...
     OtherPars => '[o] NV_ADD1 v1',

--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@
 - make HdrCode and FtrCode run when PMCode supplied (#463) - thanks @jo-37 for suggestion
 - PP add CHeader key
 - OtherPars can now be incomplete arrays of char*
+- make typemaps able to use more Perl ones like T_HVREF - thanks @jo-37
 
 2.085_01 2024-02-10
 - test, document PDL::string, make more consistent (#459) - thanks @vadim-160102 for report

--- a/t/01-pptest.t
+++ b/t/01-pptest.t
@@ -192,11 +192,12 @@ pp_def('incomp_dim',
 
 pp_addhdr('
 typedef NV NV_ADD1;
+typedef HV* NV_HR;
 ');
 pp_add_typemaps(string=><<'EOT');
-TYPEMAP: <<END_OF_TYPEMAP
 TYPEMAP
 NV_ADD1 T_NV_ADD1
+NV_HR T_HVREF
 
 INPUT
 T_NV_ADD1
@@ -205,11 +206,11 @@ T_NV_ADD1
 OUTPUT
 T_NV_ADD1
   sv_setnv($arg, $var - 1);
-END_OF_TYPEMAP
 EOT
+
 pp_def('typem',
   Pars => 'int [o] out()',
-  OtherPars => '[io] NV_ADD1 v1',
+  OtherPars => '[io] NV_ADD1 v1; NV_HR v2;',
   Code => '$out() = $COMP(v1); $COMP(v1) = 8;',
 );
 
@@ -483,13 +484,16 @@ is "$o", 4;
 $o = incomp_dim([0..3]);
 is "$o", 4;
 
-$o = typem(my $oth = 3);
+$o = typem(my $oth = 3, {});
 is "$o", 4;
 is "$oth", 7;
 
-typem($o = PDL->null, $oth = 3);
+typem($o = PDL->null, $oth = 3, {});
 is "$o", 4;
 is "$oth", 7;
+
+eval {typem($o = PDL->null, $oth = 3, []);};
+like $@, qr/^typem:.*not a HASH reference/i;
 
 incomp_in($o = PDL->null, [sequence(3), sequence(byte, 4)]);
 is "$o", 9;


### PR DESCRIPTION
Some of `ExtUtil`'s typemaps use the variables `$ALIAS` and `$pname` in their INPUT section. Using e.g.
```
TYPEMAP
my_t   T_HVREF
```
in a `.pd` file won't compile.
Defining `$ALIAS` and setting `$pname` to `$name` from `pp_def` fixes this issue.

Furthermore, the syntax given for embedded typemaps in [perlxs](https://perldoc.perl.org/perlxs#The-TYPEMAP:-Keyword) is specific within XS files. The usage of nested here-documents as specified in [PDL::PP](https://metacpan.org/dist/PDL/view/Basic/Pod/PP.pod#pp_add_typemaps) is not only unnecessary, but will emit a warning if there is neither an INPUT nor an OUTPUT section.

One unrelated fix: An unset `$handlebad` variable causes a warning when `$PP_VERBOSE` is set.