### PR TITLE
Modified documentation of srand to make it clear it is not

### DIFF
--- a/Basic/Primitive/primitive.pd
+++ b/Basic/Primitive/primitive.pd
@@ -2179,8 +2179,18 @@ As of 2.062, the generator changed from Perl's generator to xoshiro256++
 
 =for usage
 
+From within pdl:
+
  srand(); # uses current time
  srand(5); # fixed number e.g. for testing
+
+Since srand is a class function and is not exported, it does not ovewrite
+Perl's builtin srand. Hence the code above will not seed PDL's generator
+when invoked from within a Perl application. Being a class method means 
+that PDL->srand() will generate an error too. Do this instead:
+
+ PDL::srand::srand(); # uses current time
+ PDL::srand::srand(5); # fixed number e.g. for testing
 
 EOF
 	PMCode=>pp_line_numbers(__LINE__, <<'EOD'),

--- a/Basic/Primitive/primitive.pd
+++ b/Basic/Primitive/primitive.pd
@@ -2191,6 +2191,33 @@ that PDL->srand() will generate an error too. Do this instead:
 
  PDL::srand::srand(); # uses current time
  PDL::srand::srand(5); # fixed number e.g. for testing
+ 
+See why keeping the srand's straight is important:
+
+ srand(3);
+ say PDL->random(3);
+ [0.0675697331360393 0.599075396409301 0.857557628839386] # output PDL1
+ 
+ print "(";print "$_" for map { rand() } 1 .. 3 ; print ")\n";
+ (0.783234962103055 0.86367337321596 0.31170834325361)      # output Perl1
+
+
+ srand(3);
+ say PDL->random(5); 
+ [0.924203795779931 0.333781400627343 0.831579265248175] # != output PDL1
+
+ print "(";print "$_" for map { rand() } 1 .. 3 ; print ")\n";
+ (0.783234962103055 0.86367337321596 0.31170834325361) # same as output Perl1
+ 
+Contrast to 
+
+ PDL::srand(3);
+ say PDL->random(3);
+ [0.18631707882894 0.0349571597540506 0.614691270370328]
+ 
+ PDL::srand(3);
+ say PDL->random(3);
+ [0.18631707882894 0.0349571597540506 0.614691270370328] # reproduces!
 
 EOF
 	PMCode=>pp_line_numbers(__LINE__, <<'EOD'),

--- a/Basic/Primitive/primitive.pd
+++ b/Basic/Primitive/primitive.pd
@@ -2184,15 +2184,14 @@ From within pdl:
  srand(); # uses current time
  srand(5); # fixed number e.g. for testing
 
-Since srand is a class function and is not exported, it does not ovewrite
-Perl's builtin srand. Hence the code above will not seed PDL's generator
-when invoked from within a Perl application. Being a class method means 
-that PDL->srand() will generate an error too. Do this instead:
+This  code above will not seed PDL's generator, but Perl's rand in Perl.  
+So if you want to seed PDL's generator, you will have to do something like this
+in the Perl interpreter:
 
- PDL::srand::srand(); # uses current time
- PDL::srand::srand(5); # fixed number e.g. for testing
+ PDL::srand(); # uses current time
+ PDL::srand(5); # fixed number e.g. for testing
  
-See why keeping the srand's straight is important:
+See why keeping the srands straight is important (try those within Perl):
 
  srand(3);
  say PDL->random(3);

--- a/Basic/Primitive/primitive.pd
+++ b/Basic/Primitive/primitive.pd
@@ -2179,14 +2179,12 @@ As of 2.062, the generator changed from Perl's generator to xoshiro256++
 
 =for usage
 
-From within pdl:
+From within C<perldl>:
 
  srand(); # uses current time
  srand(5); # fixed number e.g. for testing
 
-This  code above will not seed PDL's generator, but Perl's rand in Perl.  
-So if you want to seed PDL's generator, you will have to do something like this
-in the Perl interpreter:
+But, from within the Perl interpreter, you will have to do something like this:
 
  PDL::srand(); # uses current time
  PDL::srand(5); # fixed number e.g. for testing


### PR DESCRIPTION
exported and does not overwrite Perl's builtin srand.