### PR TITLE
Make sure that `make coretest` uses the right build of perl, and not just whatever's first in the $PATH

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -312,10 +312,11 @@ my $coretest = join ' ', map File::Spec->catfile('t', $_.'.t'), qw(
   pdlchar pp_croaking pp_line_numbers primitive-* pthread reduce
   slice subclass thread thread_def ufunc
 );
+use Config;
 $text .= <<EOF;
 
 coretest : core
-	prove -b $coretest
+	$Config{perlpath} $Config{bin}/prove -b $coretest
 EOF
 
 $text .= <<EOF;


### PR DESCRIPTION
With this tiny Makefile.PL update, `make coretest` now passes when you’re building PDL using a perl that isn’t in the $PATH.

Without the patch:

```
~/pdl $ ../cpantesting/perl-5.32.0/bin/perl Makefile.PL
Checking if your kit is complete...
Looks good
…

~/pdl $ make test
[all pass]

~/pdl $ make coretest
…
t/ops-bitwise.t ............ Undefined subroutine &Devel::CheckLib::check_lib called at /home/david/pdl/blib/lib/PDL/Core/Dev.pm line 546.
t/ops-bitwise.t ............ Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run
…
```

With the patch:

```
~/pdl $ ../cpantesting/perl-5.32.0/bin/perl Makefile.PL
Checking if your kit is complete...
Looks good
…

~/pdl $ make test
[all pass]

~/pdl $ make coretest
[all pass]
```