### PR TITLE
Fix for the Future: Make PDL build with Perl 5.41 and newer

### DIFF
--- a/Basic/Gen/PP.pm
+++ b/Basic/Gen/PP.pm
@@ -1032,7 +1032,7 @@ sub typemap_eval { # lifted from ExtUtils::ParseXS::Eval, ignoring eg $ALIAS
   my ($var, $type, $num, $init, $pname, $arg, $ntype, $argoff, $subtype)
     = @$varhash{qw(var type num init pname arg ntype argoff subtype)};
   my $ALIAS;
-  my $rv = eval qq("$code");
+  my $rv = eval qq(qq\a$code\a);
   die $@ if $@;
   $rv;
 }

--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@
 - now slices etc with dataflow turn off backward dataflow if any input has inward-only dataflow (#485)
 - add GSL::RNG::ran_shuffle_1d
 - add IO::Pic support for XBM
+- fix typemaps for future Perl versions (#487) - thanks @HaraldJoerg
 
 2.089_02 2024-06-26
 - PDL::VectorValued::vcos into Primitive - thanks @moocow-the-bovine


### PR DESCRIPTION
Perl 5 has now simplified the syntax global typemaps.  PDL has copied part of the Perl code and should follow along. The fix has been suggested by @Leont, who also authored the simplification in Perl5.

This fixes #487.