### PR TITLE
Fix spelling errors.

### DIFF
--- a/Basic/Pod/Dataflow.pod
+++ b/Basic/Pod/Dataflow.pod
@@ -61,7 +61,7 @@ it for non-flowing operations (see L<PDL::Core/flowing>), so
 
 C<flowing> operates by turning on a flag that the core turns off
 immediately after acting on it (rather like C<inplace>), so it only
-operates on the next operation (aka transfrom) called on that ndarray,
+operates on the next operation (aka transform) called on that ndarray,
 making that operation be a forward-flowing one. That lasts until the
 output(s) of that operation get C<sever>ed.
 

--- a/Basic/Pod/PP.pod
+++ b/Basic/Pod/PP.pod
@@ -27,7 +27,7 @@ PDL::PP - Generate PDL routines from concise descriptions
 
 =head1 OVERVIEW
 
-PDL::PP prepares Perl modules and the C sources and allows to write
+PDL::PP prepares Perl modules and the C sources and allows writing
 software which can be called from Perl but executes with C speed -
 with ease.  These C sources need to be compiled before your code can be
 executed.  There are two modes of operation for this:

--- a/Basic/Pod/QuickStart.pod
+++ b/Basic/Pod/QuickStart.pod
@@ -13,7 +13,7 @@ A brief summary of the main PDL features and how to use them.
 
 Perl is an extremely good and versatile scripting language, well suited to
 beginners and allows rapid prototyping.  However the Perl core does not
-support data structures which allow to do fast number crunching.
+support data structures which allow doing fast number crunching.
 
 With the development of Perl v5, Perl acquired 'Objects'. To put
 it simply, users can define their own special data types, and write


### PR DESCRIPTION
The lintian QA tool reported spelling errors for the Debian package build:

 * allow to <verb>  -> allow <verb>ing
 * allows to <verb> -> allows <verb>ing
 * transfrom        -> transform