### PR TITLE
approx fails for complex values

### DIFF
--- a/Basic/lib/PDL/Primitive.pd
+++ b/Basic/lib/PDL/Primitive.pd
@@ -2437,51 +2437,51 @@ The default value of C<mode> is C<sample>.
 =for example
 
   use PDL;
-  
+
   my @modes = qw( sample insert_leftmost insert_rightmost match
                   bin_inclusive bin_exclusive );
-  
+
   # Generate a sequence of 3 zeros, 3 ones, ..., 3 fours.
   my $x = zeroes(3,5)->yvals->flat;
-  
+
   for my $mode ( @modes ) {
     # if the value is in $x
     my $contained = 2;
     my $idx_contained = vsearch( $contained, $x, { mode => $mode } );
     my $x_contained = $x->copy;
     $x_contained->slice( $idx_contained ) .= 9;
-    
+
     # if the value is not in $x
     my $not_contained = 1.5;
     my $idx_not_contained = vsearch( $not_contained, $x, { mode => $mode } );
     my $x_not_contained = $x->copy;
     $x_not_contained->slice( $idx_not_contained ) .= 9;
-    
+
     print sprintf("%-23s%30s\n", '$x', $x);
     print sprintf("%-23s%30s\n",   "$mode ($contained)", $x_contained);
     print sprintf("%-23s%30s\n\n", "$mode ($not_contained)", $x_not_contained);
   }
-  
+
   # $x                     [0 0 0 1 1 1 2 2 2 3 3 3 4 4 4]
   # sample (2)             [0 0 0 1 1 1 9 2 2 3 3 3 4 4 4]
   # sample (1.5)           [0 0 0 1 1 1 9 2 2 3 3 3 4 4 4]
-  # 
+  #
   # $x                     [0 0 0 1 1 1 2 2 2 3 3 3 4 4 4]
   # insert_leftmost (2)    [0 0 0 1 1 1 9 2 2 3 3 3 4 4 4]
   # insert_leftmost (1.5)  [0 0 0 1 1 1 9 2 2 3 3 3 4 4 4]
-  # 
+  #
   # $x                     [0 0 0 1 1 1 2 2 2 3 3 3 4 4 4]
   # insert_rightmost (2)   [0 0 0 1 1 1 2 2 2 9 3 3 4 4 4]
   # insert_rightmost (1.5) [0 0 0 1 1 1 9 2 2 3 3 3 4 4 4]
-  # 
+  #
   # $x                     [0 0 0 1 1 1 2 2 2 3 3 3 4 4 4]
   # match (2)              [0 0 0 1 1 1 2 9 2 3 3 3 4 4 4]
   # match (1.5)            [0 0 0 1 1 1 2 2 9 3 3 3 4 4 4]
-  # 
+  #
   # $x                     [0 0 0 1 1 1 2 2 2 3 3 3 4 4 4]
   # bin_inclusive (2)      [0 0 0 1 1 1 2 2 9 3 3 3 4 4 4]
   # bin_inclusive (1.5)    [0 0 0 1 1 9 2 2 2 3 3 3 4 4 4]
-  # 
+  #
   # $x                     [0 0 0 1 1 1 2 2 2 3 3 3 4 4 4]
   # bin_exclusive (2)      [0 0 0 1 1 9 2 2 2 3 3 3 4 4 4]
   # bin_exclusive (1.5)    [0 0 0 1 1 9 2 2 2 3 3 3 4 4 4]
@@ -3600,7 +3600,7 @@ double abs_diff2 = PDL_IF_GENTYPE_REAL(
 if (abs_diff2 <= atol2)                 { $result() = 1; continue; }
 double rel_diff2 = rtol2 * PDL_IF_GENTYPE_REAL(
   expctd * expctd,
-  (creall(expctd) * creall(expctd)) + (cimagl(expctd) * cimagl(expctd))
+  ((creall(expctd) * creall(expctd)) + (cimagl(expctd) * cimagl(expctd)))
 );
 if (abs_diff2 <= rel_diff2)             { $result() = 1; continue; }
 $result() = 0;

--- a/Basic/t/primitive-misc.t
+++ b/Basic/t/primitive-misc.t
@@ -82,6 +82,8 @@ subtest approx_artol => sub {
   $got_a = pdl('inf bad')->approx_artol(pdl('inf bad'));
   $exp_a_mask = pdl([1,1]);
   ok all($got_a == $exp_a_mask), 'inf,bad matches inf,bad' or diag "got=$got_a\nexp=$exp_a_mask";
+  ok all(approx_artol i,i), 'i is approx i';
+  ok !all(approx_artol i,5*i), 'i is not approx 5i';
 };
 
 done_testing;

--- a/Changes
+++ b/Changes
@@ -27,6 +27,7 @@
 - split PDL::IO::Dicom out to separate distro
 - finish, then split PDL::IO::ENVI out to separate distro
 - split PDL::Graphics::TriD out to separate distro
+- fix approx_artol for complex values (#507) - thanks @wlmb
 
 2.095 2024-11-03
 - add PDL_GENTYPE_IS_{REAL,FLOATREAL,COMPLEX,SIGNED,UNSIGNED}_##ppsym (#502)


### PR DESCRIPTION
There was a misterious error according to which complex numbers like i and 5i were considered approximately equal. I corrected the error by putting parenthesis around the macro 
    PDL_IF_GENTYPE_REAL(<code if real>, <code if complex>)
    ->
    (PDL_IF_GENTYPE_REAL(<code if real>, <code if complex>) )
I guess something is wrong in the expansion of the macro, but haven't looked at it.