### PR TITLE
PDL::IO::Dumper: better handling of multiply referenced ndarrays

### DIFF
--- a/lib/PDL/IO/Dumper.pm
+++ b/lib/PDL/IO/Dumper.pm
@@ -532,9 +532,9 @@ sub PDL::IO::Dumper::find_PDLs {
   }
 
   #  deduplicate
-  my %seen;
-  $out = join "\n", grep {!$seen{$_}++} split ("\n", $out);
-  $out .= "\n";
+  # my %seen;
+  # $out = join "\n", grep {!$seen{$_}++} split ("\n", $out);
+  # $out .= "\n";
 
   return $out;
 }

--- a/lib/PDL/IO/Dumper.pm
+++ b/lib/PDL/IO/Dumper.pm
@@ -95,6 +95,7 @@ convenience routine exists to use it.
 
 sub PDL::IO::Dumper::sdump {
 # Make an initial dump...
+  local $Data::Dumper::Purity = 1;
   my($s) = Data::Dumper->Dump([@_]);
   my(%pdls);
 # Find the bless(...,'PDL') lines
@@ -114,7 +115,7 @@ sub PDL::IO::Dumper::sdump {
   # find_PDLs call (which modifies $s using the s/// operator).
 
   my($s2) =  "{my(\$VAR1);\n".&PDL::IO::Dumper::find_PDLs(\$s,@_)."\n\n";
-  return $s2.$s."\n}";
+  return $s2.$s."\n\$VAR1}";
 
 #
 }
@@ -529,6 +530,12 @@ sub PDL::IO::Dumper::find_PDLs {
     }
   
   }
+
+  #  deduplicate
+  my %seen;
+  $out = join "\n", grep {!$seen{$_}++} split ("\n", $out);
+  $out .= "\n";
+
   return $out;
 }
 

--- a/lib/PDL/IO/Dumper.pm
+++ b/lib/PDL/IO/Dumper.pm
@@ -489,25 +489,27 @@ string.  You shouldn't call this unless you know what you're doing.
 =cut
 
 sub PDL::IO::Dumper::find_PDLs {
-  local($_);
-  my($out)="";
-  my($sp) = shift;
+  my($sp, @items) = @_;
 
-  findpdl:foreach $_(@_) {
-    next findpdl unless ref($_);
+  my $out = "";
 
-    if(UNIVERSAL::isa($_,'ARRAY')) {
+  findpdl:
+  foreach my $item (@items) {
+    next findpdl unless ref($item);
+
+    if(UNIVERSAL::isa($item,'ARRAY')) {
       my($x);
-      foreach $x(@{$_}) {
-	$out .= find_PDLs($sp,$x);
+      foreach $x(@{$item}) {
+        $out .= find_PDLs($sp,$x);
       }
     } 
-    elsif(UNIVERSAL::isa($_,'HASH')) {
+    elsif(UNIVERSAL::isa($item,'HASH')) {
       my($x);
-      foreach $x(values %{$_}) {
-	$out .= find_PDLs($sp,$x)
-	}
-    } elsif(UNIVERSAL::isa($_,'PDL')) {
+      foreach $x(values %{$item}) {
+        $out .= find_PDLs($sp,$x)
+      }
+    }
+    elsif(UNIVERSAL::isa($item,'PDL')) {
 
       # In addition to straight PDLs, 
       # this gets subclasses of PDL, but NOT magic-hash subclasses of
@@ -516,17 +518,17 @@ sub PDL::IO::Dumper::find_PDLs {
       # just a straight PDL (and not a hash with PDL field), you end up here.
       #
 
-      my($pdlid) = sprintf('PDL_%u',$$_);
-      my(@strings) = &PDL::IO::Dumper::dump_PDL($_,$pdlid);
+      my($pdlid) = sprintf('PDL_%u',$$item);
+      my(@strings) = &PDL::IO::Dumper::dump_PDL($item,$pdlid);
       
       $out .= $strings[0];
       $$sp =~ s/\$$pdlid/$strings[1]/g if(defined($strings[1]));  
     }
-    elsif(UNIVERSAL::isa($_,'SCALAR')) {
+    elsif(UNIVERSAL::isa($item,'SCALAR')) {
       # This gets other kinds of refs -- PDLs have already been gotten.
       # Naked PDLs are themselves SCALARs, so the SCALAR case has to come 
       # last to let the PDL case run.
-      $out .= find_PDLs( $sp, ${$_} );
+      $out .= find_PDLs( $sp, ${$item} );
     }
   
   }

--- a/t/dumper.t
+++ b/t/dumper.t
@@ -54,4 +54,37 @@ is ref($x), 'ARRAY' or diag explain $s;
 ok eval { $x->[0]->hdrcpy() == 1 && $x->[1]->hdrcpy() == 0 }, 'Check hdrcpy()\'s persist';
 ok eval { ($x->[0]->gethdr()->{ok}==1) && ($x->[1]->gethdr()->{ok}==2) }, 'Check gethdr() values persist';
 
+#  GH508
+{
+    my $x = xvals(5);
+    my $y1 = $x;
+    my $y2 = 2*$x;
+    my $y3 = $x*$x;
+
+    my %plots = (
+        'x1'=>$x, 'y1'=>$y1,
+        'x2'=>$x, 'y2'=>$y2,
+        'x3'=>$x, 'y3'=>$y3,
+    );
+
+    my $as_string = sdump \%plots;
+
+    my $restored = eval $as_string;
+
+    #diag $as_string;
+
+    my @nulls = grep {!defined $restored->{$_}} sort keys %$restored;
+    is_deeply \@nulls, [], 'none of the restored items are undef';
+
+    #  test a dump with uuencoded content
+    my $u = xvals(25,25);
+    my @ndarrays = ($u, $u);
+    $as_string = sdump \@ndarrays;
+    # diag $as_string;
+    $restored = eval $as_string;
+    @nulls = grep {!defined $_} @$restored;
+    is_deeply \@nulls, [], 'none of the restored uuencoded items are undef';
+
+}
+
 done_testing;

--- a/t/dumper.t
+++ b/t/dumper.t
@@ -72,7 +72,7 @@ ok eval { ($x->[0]->gethdr()->{ok}==1) && ($x->[1]->gethdr()->{ok}==2) }, 'Check
 
     my $restored = eval $as_string;
 
-    diag $as_string;
+    # diag $as_string;
 
     my @nulls = grep {!defined $restored->{$_}} sort keys %$restored;
     is_deeply \@nulls, [], 'none of the restored items are undef';

--- a/t/dumper.t
+++ b/t/dumper.t
@@ -56,7 +56,8 @@ ok eval { ($x->[0]->gethdr()->{ok}==1) && ($x->[1]->gethdr()->{ok}==2) }, 'Check
 
 #  GH508
 {
-    my $x = xvals(5);
+    #  need 10 vals to trigger GH508
+    my $x = xvals(10);
     my $y1 = $x;
     my $y2 = 2*$x;
     my $y3 = $x*$x;
@@ -71,7 +72,7 @@ ok eval { ($x->[0]->gethdr()->{ok}==1) && ($x->[1]->gethdr()->{ok}==2) }, 'Check
 
     my $restored = eval $as_string;
 
-    #diag $as_string;
+    diag $as_string;
 
     my @nulls = grep {!defined $restored->{$_}} sort keys %$restored;
     is_deeply \@nulls, [], 'none of the restored items are undef';

--- a/t/dumper.t
+++ b/t/dumper.t
@@ -14,7 +14,16 @@ use PDL::LiteF;
 
 my ( $s, $x );
 
-eval { $s = sdump({a=>3,b=>pdl(4),c=>xvals(3,3),d=>xvals(4,4)}) };
+#  Need a value greater than the uuencode dump threshold.
+#  Currently 25 but may change in future.
+my $big_size = int (5 + sqrt $PDL::IO::Dumper::med_thresh);
+my @big_dims = ($big_size, $big_size);
+
+#  Small thresh is currently 8
+my $med_size = int (2 + sqrt $PDL::IO::Dumper::small_thresh);
+my @med_dims = ($med_size, $med_size);
+
+eval { $s = sdump({a=>3,b=>pdl(4),c=>xvals(3,3),d=>xvals(@med_dims)}) };
 is $@, '', 'Call sdump()'
    or diag("Call sdump() output string:\n$s\n");
 $x = eval $s;
@@ -24,27 +33,35 @@ ok(($x->{a}==3), 'SCALAR value restored ok');
 ok(((ref $x->{b} eq 'PDL') && ($x->{b}==4)), '0-d PDL restored ok');
 ok(((ref $x->{c} eq 'PDL') && ($x->{c}->nelem == 9) 
       && (sum(abs(($x->{c} - xvals(3,3))))<0.0000001)), '3x3 PDL restored ok');
-ok(((ref $x->{d} eq 'PDL') && ($x->{d}->nelem == 16)
-      && (sum(abs(($x->{d} - xvals(4,4))))<0.0000001)), '4x4 PDL restored ok');
+ok(((ref $x->{d} eq 'PDL') && ($x->{d}->nelem == $med_size ** 2)
+      && (sum(abs(($x->{d} - xvals(@med_dims))))<0.0000001)), '"medium" sized PDL restored ok');
 
 ########## Dump a uuencoded expr and try to get it back...
 # e: uuencoded expr
-eval { $s = sdump({e=>xvals(25,25)}) };
-is $@, '', 'sdump() of 25x25 PDL to test uuencode dumps';
+eval { $s = sdump({e=>xvals(@big_dims)}) };
+is $@, '', 'sdump() of "big" PDL to test uuencode dumps';
 
 #diag $s,"\n";
 
 $x = eval $s;
-is $@, '', 'Can eval dumped 25x25 PDL' or diag 'string: ', $s;
+is $@, '', 'Can eval dumped "big" PDL' or diag 'string: ', $s;
 
-ok((ref $x eq 'HASH'), 'HASH structure for uuencoded 25x25 PDL restored');
+ok((ref $x eq 'HASH'), 'HASH structure for uuencoded "big" PDL restored');
 isa_ok $x->{e}, 'PDL';
-is $x->{e}->nelem, 625;
-is_pdl $x->{e}, xvals(25,25), 'Verify 25x25 PDL restored data';
+is $x->{e}->nelem, $big_size ** 2;
+is_pdl $x->{e}, xvals(@big_dims), 'Verify "big" PDL restored data';
 
 ########## Check header dumping...
 my $y;
-eval { $x = xvals(2,2); $x->sethdr({ok=>1}); $x->hdrcpy(1); $y = xvals(25,25); $y->sethdr({ok=>2}); $y->hdrcpy(0); $s = sdump([$x,$y,yvals(25,25)]); };
+eval {
+    $x = xvals(2,2);
+    $x->sethdr({ok=>1});
+    $x->hdrcpy(1);
+    $y = xvals(@big_dims);
+    $y->sethdr({ok=>2});
+    $y->hdrcpy(0);
+    $s = sdump([$x,$y,yvals(@big_dims)]);
+};
 is $@, '', 'Check header dumping';
 
 $x = eval $s;
@@ -78,7 +95,7 @@ ok eval { ($x->[0]->gethdr()->{ok}==1) && ($x->[1]->gethdr()->{ok}==2) }, 'Check
     is_deeply \@nulls, [], 'none of the restored items are undef';
 
     #  test a dump with uuencoded content
-    my $u = xvals(25,25);
+    my $u = xvals(@big_dims);
     my @ndarrays = ($u, $u);
     $as_string = sdump \@ndarrays;
     # diag $as_string;


### PR DESCRIPTION
 * Keep a track of which ndarrays have already been dumped to avoid duplicating them in the dump string.
 * Handle multiple refs in the dumper structure.  
 * Generalise dumper tests to handle future changes to dump method thresholds.  

Includes some modernisation of code.  More could be done but that's better as a separate PR.  

Fixes #508 