### PR TITLE
Fix spelling errors.

### DIFF
--- a/lib/PDL/IO/Pic.pm
+++ b/lib/PDL/IO/Pic.pm
@@ -541,7 +541,7 @@ to byte if the input if of type float/double.  Input data that is of a
 signed integer type and contains negative numbers will be rejected.
 
 If you append C<.gz> or C<.Z> to the end of the file name, the final
-file will be automatically compresed with L<"gzip"|gzip> |
+file will be automatically compressed with L<"gzip"|gzip> |
 L<"compress"|compress>, respectively.
 
 OPTIONS

--- a/lib/PDL/Parallel/threads.pm
+++ b/lib/PDL/Parallel/threads.pm
@@ -542,7 +542,7 @@ you know what's going on if you get this. :-)
 
 =back
 
-=item C<< share_pdls passed data under '$name' that it doesn't know how to
+=item C<< share_pdls passed data under '$name' that it does not know how to
 store >>
 
 C<share_pdls> only knows how to store raw data

--- a/lib/PDL/Parallel/threads/SIMD.pm
+++ b/lib/PDL/Parallel/threads/SIMD.pm
@@ -230,7 +230,7 @@ thread-specific fashion based on the parallel thread id.
  # Share it.
  $to_sum->share_as('to-sum');
 
- # Also allocate some shared, temproary memory:
+ # Also allocate some shared, temporary memory:
  my $N_threads = 10;
  zeroes($N_threads)->share_as('workspace');
 


### PR DESCRIPTION
The lintian QA reported spelling errors for the Debian package build:

 * compresed -> compressed
 * doesnt    -> does not
 * temproary -> temporary

Note that the "doesn't" typo is caused by single quotes being stripped.