### PR TITLE
Add FREEZE and THAW methods for serialisation

### DIFF
--- a/Changes
+++ b/Changes
@@ -16,6 +16,7 @@
 - "usage" section of xform docs now automatically generated (#519)
 - overloaded operators now throw exception if given undef argument (#519) - thanks @cgtinney for report
 - Core::dog now scales linearly with length of top dim, not O(n^2) (#421) - thank @djerius for report
+- PDL::IO::Storable now also supports Sereal, JSON::MaybeXS, CBOR::XS (#510,#520) - thanks @shawnlaffan
 
 2.098 2025-01-03
 - fix Windows build problems

--- a/lib/PDL/Complex/Overloads.pm
+++ b/lib/PDL/Complex/Overloads.pm
@@ -6,6 +6,16 @@ use overload fallback => 1;
 
 sub cplx { bless &Math::Complex::cplx, __PACKAGE__ }
 
+#  needed for JSON serialisation
+sub FREEZE {
+    my ($self, $serialiser) = @_;
+    return %$self;
+}
+sub THAW {
+    my ($self, $serialiser, @data) = @_;
+    return bless {@data}, $self;
+}
+
 =head1 NAME
 
 PDL::Complex::Overloads - subclass of Math::Complex with overload fallbacks

--- a/lib/PDL/IO/Storable.pm
+++ b/lib/PDL/IO/Storable.pm
@@ -34,14 +34,22 @@ PDL::IO::Storable - helper functions to make PDL usable with serialisation packa
 
 =head1 DESCRIPTION
 
-Serialisation packages such as C<Storable>, C<Sereal>, C<JSON::MaybeXS> and C<CBOR::XS> implement
+Serialisation packages such as C<Storable>, C<Sereal>, C<JSON::MaybeXS>
+and C<CBOR::XS> implement
 object persistence for Perl data structures that can
 contain arbitrary Perl objects. This module implements the relevant methods to
 be able to store and retrieve ndarrays via C<Storable> as well as packages that support
-the C<Types::Serialiser> protocol (currently C<Sereal>, C<CBOR::XS> and JSON packages).
+the L<Types::Serialiser> protocol (currently L<Sereal>, L<CBOR::XS> and JSON packages).
 
 Note that packages supporting the C<Types::Serialiser> protocol need to have their
 respective flags enabled so that the FREEZE and THAW callbacks are used.
+
+Note also that while L<JSON::MaybeXS> is supported, if it has to
+fall back to L<JSON::PP>, it will fail. L<JSON::XS> treats the data
+it gets back from C<FREEZE> as items to encode, while L<JSON::PP>
+treats the list it gets as strings already encoded. They are
+fundamentally incompatible, so this module supports the JSON::XS
+option.
 
 =head1 FUNCTIONS
 

--- a/t/storable.t
+++ b/t/storable.t
@@ -83,6 +83,11 @@ is_pdl thaw($f2), sequence(long,5), "thawed byte-swapped";
   my @serialisers;
   for my $module (@possibles) {
     if (eval "require $module") {
+      if ($module eq 'JSON::MaybeXS') {
+        my $impl = eval { $module->JSON };
+        note("JSON::XS wants data to encode, JSON::PP wants encoded: can't work with JSON::PP"), next
+          if ($impl || '') eq 'JSON::PP';
+      }
       push @serialisers, $module;
     }
     else {
@@ -120,10 +125,8 @@ is_pdl thaw($f2), sequence(long,5), "thawed byte-swapped";
 
     foreach my $pair (@ndarrays) {
       my ($name, $ndarray) = @$pair;
-
       my $frozen = $encoder->encode($ndarray);
       my $thawed = $decoder->decode($frozen);
-
       is_pdl($thawed, $ndarray, "$name thawed correctly using $serialiser");
     }
   }

--- a/t/storable.t
+++ b/t/storable.t
@@ -75,6 +75,60 @@ substr $f2, -20, 20, $data;
 is_pdl thaw($f2), sequence(long,5), "thawed byte-swapped";
 }
 
+#  packages supporting Types::Serialiser protocol
+{
+  #  add to if needed
+  my @possibles = qw/Sereal CBOR::XS JSON::MaybeXS/;
+
+  my @serialisers;
+  for my $module (@possibles) {
+    if (eval "require $module") {
+      push @serialisers, $module;
+    }
+    else {
+      note "package $module not available for serialisation, not testing it";
+    }
+  }
+
+  if (!@serialisers) {
+    diag "No serialisation modules installed that support the Types::Serialiser protocol, skipping those tests";
+  }
+
+  my @ndarrays = (
+      [ xvals => xvals(2, 2) ],
+      [ cdouble => pdl(cdouble, 2, 3) ],
+      [ cdouble2 => xvals(cdouble, 3, 5) + 10 - 2 * xvals(3, 5) * i ],
+      [ indx => pdl(indx, 2, 3) ],
+      [ ldouble => pdl(ldouble, 2, 3) ],
+  );
+
+  my ($encoder, $decoder);
+
+  foreach my $serialiser (@serialisers) {
+    if ($serialiser eq 'Sereal') {
+      $encoder = Sereal::Encoder->new({ freeze_callbacks => 1 });
+      $decoder = Sereal::Decoder->new({ freeze_callbacks => 1 });
+    }
+    elsif ($serialiser eq 'CBOR::XS') {
+      $encoder = CBOR::XS->new;
+      $decoder = CBOR::XS->new;
+    }
+    elsif ($serialiser eq 'JSON::MaybeXS') {
+      $encoder = JSON::MaybeXS->new(allow_tags => 1);
+      $decoder = JSON::MaybeXS->new(allow_tags => 1);
+    }
+
+    foreach my $pair (@ndarrays) {
+      my ($name, $ndarray) = @$pair;
+
+      my $frozen = $encoder->encode($ndarray);
+      my $thawed = $decoder->decode($frozen);
+
+      is_pdl($thawed, $ndarray, "$name thawed correctly using $serialiser");
+    }
+  }
+}
+
 done_testing;
 
 # tests loading some files made on different architectures. All these files were


### PR DESCRIPTION
Tests work with Serial, JSON::MaybeXS, CBOR::XS ~and CBOR::Free~.  (Edit: `CBOR::Free` was a false positive - it does not support FREEZE/THAW).

I also had a look at testing with some of the YAML modules but they do not support FREEZE/THAW callbacks.  

Could probably be squashed into a single commit before merging, thus cleaning up debugging cruft.  

Documentation is still needed.  It should just comprise a note that serialisers that conform to `Types::Serialiser` are (should be) supported.  

I'm not sure where to add it, though, as it does not fit under `PDL::IO::Storable`.  Perhaps its contents could be shifted to a new PDL::IO::Serialisation or similar which is then loaded by default with the rest of PDL.  That might be too large a change, though.  