### PR TITLE
Add bxor and bxorover

### DIFF
--- a/lib/PDL/Ops.pd
+++ b/lib/PDL/Ops.pd
@@ -300,6 +300,11 @@ biop('and2','&',1,'bitwise I<and> of two ndarrays',GenericTypes => $T,
 biop('xor','^',1,'bitwise I<exclusive or> of two ndarrays',GenericTypes => $T,
       Bitwise => 1);
 
+pp_addpm(
+"=head2 xor2\n\n=for ref\n\nSynonym for L</xor>.\n\n=cut\n
+*PDL::xor2 = *xor2 = \\&PDL::xor;"
+    );
+
 ufunc('bitnot','~',1,'unary bitwise negation',GenericTypes => $T);
 
 # some standard binary functions

--- a/lib/PDL/Ufunc.pd
+++ b/lib/PDL/Ufunc.pd
@@ -636,7 +636,11 @@ for my $op ( ['avg','average','average'],
 	     ['band','bandover','bitwise and'],
 	     ['or','orover','logical or'],
 	     ['bor','borover','bitwise or'],
+<<<<<<< HEAD
 	     ['xorall','orover','logical xor'],
+=======
+	     ['xorall','xorover','logical xor'],
+>>>>>>> 9d74b5b5 (add logical xor and tests)
 	     ['bxor','bxorover','bitwise xor'],
 	     ['min','minimum','minimum'],
 	     ['max','maximum','maximum'],

--- a/lib/PDL/Ufunc.pd
+++ b/lib/PDL/Ufunc.pd
@@ -148,10 +148,14 @@ EOF
     op => 'tmp &=  ($a() != 0);', leftzero => '!tmp' },
   orover => { def=>'char tmp', txt => 'logical or', alltypes => 1,
     op => 'tmp |= ($a() != 0);', leftzero => 'tmp' },
+  xorover => { def=>'char tmp', txt => 'logical xor', alltypes => 1,
+    op => 'tmp ^= ($a() != 0);', leftzero => 0 },
   bandover => { txt => 'bitwise and', init => '~0',
     op => 'tmp &= $a();', leftzero => '!tmp' },
   borover => { txt => 'bitwise or',
     op => 'tmp |= $a() ;', leftzero => '!~tmp' },
+  bxorover  => { txt => 'bitwise xor',
+    op => 'tmp ^= $a() ;', leftzero => 0 },
 );
 foreach my $func ( sort keys %over ) {
   my ($def,$txt,$init,$op,$leftzero) = @{$over{$func}}{qw(def txt init op leftzero)};
@@ -632,6 +636,8 @@ for my $op ( ['avg','average','average'],
 	     ['band','bandover','bitwise and'],
 	     ['or','orover','logical or'],
 	     ['bor','borover','bitwise or'],
+	     ['xorall','orover','logical xor'],
+	     ['bxor','bxorover','bitwise xor'],
 	     ['min','minimum','minimum'],
 	     ['max','maximum','maximum'],
 	     ['median', 'medover', 'median'],

--- a/lib/PDL/Ufunc.pd
+++ b/lib/PDL/Ufunc.pd
@@ -636,11 +636,7 @@ for my $op ( ['avg','average','average'],
 	     ['band','bandover','bitwise and'],
 	     ['or','orover','logical or'],
 	     ['bor','borover','bitwise or'],
-<<<<<<< HEAD
-	     ['xorall','orover','logical xor'],
-=======
 	     ['xorall','xorover','logical xor'],
->>>>>>> 9d74b5b5 (add logical xor and tests)
 	     ['bxor','bxorover','bitwise xor'],
 	     ['min','minimum','minimum'],
 	     ['max','maximum','maximum'],

--- a/t/ops.t
+++ b/t/ops.t
@@ -272,6 +272,8 @@ SKIP:
 
 is_pdl ~pdl(1,2,3), longlong('[-2 -3 -4]'), 'bitwise negation';
 is_pdl pdl(1,2,3) ^ pdl(4,5,6), longlong('[5 7 5]'), 'bitwise xor';
+is_pdl do {PDL::xor2(pdl(1,2,3), pdl(4,5,6), my $out = null, 0); $out},
+    longlong('[5 7 5]'), 'alias xor2';
 
 {
 my $startgood = sequence(10);

--- a/t/ufunc.t
+++ b/t/ufunc.t
@@ -157,6 +157,18 @@ is( pdl([10,0,-4])->setvaltobad(0)->borover(), -2, "borover with BAD values");
 #AND: 1111 1000 = 248 if the accumulator in BadCode is an unsigned char
 is( pdl([-6,~0,-4])->setvaltobad(~0)->bandover(), -8, "bandover with BAD values");
 
+#     0000 0110
+#     1111 1110
+#XOR: 1111 1000 = -8
+is( longlong([6, 0, -2])->bxorover(), -8, "bxorover with no BAD values");
+
+is( longlong([6, 0, -2])->setvaltobad(0)->bxorover(), -8, "bxorover with BAD values");
+is( longlong([6, 0, -2])->bxor(), -8, "bxor");
+
+is( longlong([-1, 0, 2])->xorover(), 0, "xorover with no BAD values");
+is( longlong([-1, 0, 2])->setvaltobad(0)->xorover(), 0, "xorover with BAD values");
+is( longlong([-1, 0, 2])->xorall(), 0, "xorall");
+
 {
   # all calls to functions that handle finding minimum and maximum should return
   # the same values (i.e., BAD).  NOTE: The problem is that perl scalar values


### PR DESCRIPTION
Analogous to the other bitwise methods. I don't see a need for _logical_ `xor` as it can easily be emulated using e.g. `(!!$x)->sum % 2`.