### PR TITLE
Add option 'NoExport' to pp_def

### DIFF
--- a/lib/PDL/Ops.pd
+++ b/lib/PDL/Ops.pd
@@ -136,6 +136,7 @@ EOF
 	   NoBadifNaN => 1,
 	   Inplace => [ 'a' ],
 	   Overload => [$op, $mutator, $bitwise],
+	   NoExport => 1,
 	   Code => pp_line_numbers(__LINE__, <<EOF),
 PDL_IF_BAD(char anybad = 0;,)
 broadcastloop %{
@@ -193,6 +194,7 @@ ENDCODE
 	   OtherParsDefaults => { swap => 0 },
 	   Inplace => [ 'a' ],
 	   Overload => [$funcov, $mutator],
+	   NoExport => 1,
 	   Code => pp_line_numbers(__LINE__, <<EOF),
 PDL_IF_BAD(char anybad = 0;,)
 broadcastloop %{
@@ -242,6 +244,7 @@ sub ufunc {
 	   NoBadifNaN => 1,
 	   Inplace => 1,
 	   !$overload ? () : (Overload => $funcov),
+	   NoExport => 1,
 	   Code => pp_line_numbers(__LINE__, <<EOF),
 PDL_IF_BAD(if ( \$ISBAD(a()) ) \$SETBAD(b()); else {,)
   $codestr
@@ -305,8 +308,6 @@ pp_addpm(
 *PDL::xor2 = *xor2 = \\&PDL::xor;"
     );
 
-ufunc('bitnot','~',1,'unary bitwise negation',GenericTypes => $T);
-
 # some standard binary functions
 bifunc('power',['pow','op**'],1,'raise ndarray C<$a> to the power C<$b>',GenericTypes => [@$C, @$F]);
 bifunc('atan2','atan2',0,'elementwise C<atan2> of two ndarrays',GenericTypes => $F);
@@ -314,6 +315,7 @@ bifunc('modulo',['MOD','op%'],1,'elementwise C<modulo> operation',unsigned=>1);
 bifunc('spaceship',['SPACE','op<=>'],0,'elementwise "<=>" operation');
 
 # some standard unary functions
+ufunc('bitnot','~',1,'unary bitwise negation',GenericTypes => $T);
 ufunc('sqrt','sqrt',1,'elementwise square root', GenericTypes => $A); # Exception => '$a() < 0');
 ufunc('sin','sin',1,'the sin function', GenericTypes => $A);
 ufunc('cos','cos',1,'the cos function', GenericTypes => $A);
@@ -340,6 +342,7 @@ pp_def ( '_rabs',
 	HandleBad => 1,
 	NoBadifNaN => 1,
 	    Inplace => 1,
+	NoExport => 1,
 	Code => pp_line_numbers(__LINE__-1, qq{
 PDL_IF_BAD(if ( \$ISBAD(a()) ) \$SETBAD(b()); else,)
   $rabs_code
@@ -348,13 +351,12 @@ PDL_IF_BAD(if ( \$ISBAD(a()) ) \$SETBAD(b()); else,)
 	PMFunc=>'',
 );
 
-pp_export_nothing();
-
 # make log10() work on scalars (returning scalars)
 # as well as ndarrays
 ufunc('log10','log10',0,'the base 10 logarithm', GenericTypes => $A,
       Exception => '$a() <= 0',
       NoTgmath => 1, # glibc for at least GCC 8.3.0 won't tgmath log10 though 7.1.0 did
+      NoExport => 0,
       PMCode => <<'EOF',
 sub PDL::log10 {
     my ($x, $y) = @_;
@@ -396,6 +398,7 @@ sub cfunc {
 	   HandleBad => 1,
 	   NoBadifNaN => 1,
 	   (($make_real || $force_complex) ? () : (Inplace => 1)),
+	   NoExport => 1,
 	   Code => pp_line_numbers(__LINE__-1, qq{
 PDL_IF_BAD(if ( \$ISBAD(complexv()) ) \$SETBAD(b()); else,)
   $codestr
@@ -414,8 +417,8 @@ PDL_IF_BAD(if ( \$ISBAD(complexv()) ) \$SETBAD(b()); else,)
     );
 }
 
-cfunc('carg', 'carg', 1, 1, 'Returns the polar angle of a complex number.', undef);
-cfunc('conj', 'conj', 0, 0, 'complex conjugate.', undef);
+cfunc('carg', 'carg', 1, 1, 'Returns the polar angle of a complex number.', undef, NoExport => 0);
+cfunc('conj', 'conj', 0, 0, 'complex conjugate.', undef, NoExport => 0);
 
 pp_def('czip',
   Pars => '!complex r(); !complex i(); complex [o]c()',

--- a/lib/PDL/PP.pod
+++ b/lib/PDL/PP.pod
@@ -1872,6 +1872,22 @@ Implements overloading of Perl operators. Documented automatically.
 Added in PDL 2.099. Will overload in the current C<pp_bless> package,
 which defaults to C<PDL>.
 
+=head3 NoExport
+
+=over 4
+
+=item NoExport => 1
+
+=back
+
+A function that is defined by C<pp_def> will be automatically added
+to the module's export list.
+
+By specifying a C<true> value for C<NoExport> this behaviour can be
+suppressed.
+
+Added in PDL 2.100.
+
 =head3 ParamDesc
 
   # in Primitive.pd
@@ -2954,6 +2970,9 @@ called C<pp_export_clear>, since you can add exported symbols after calling
 C<pp_export_nothing>. When called just before calling pp_done, this ensures
 that your module does not export anything, for example, if you only want
 programmers to use your functions as methods.
+
+By specifying a C<true> value for the key C<NoExport> in C<pp_def>, the
+defined function will be exempt from being exported.
 
 =head1 SEE ALSO
 

--- a/t/ops.t
+++ b/t/ops.t
@@ -283,4 +283,47 @@ is_pdl $startgood, pdl('0 1 2 BAD 4 5 6 7 8 9'), 'now badflag true';
 
 is_deeply [(zeroes(1,1,0) & zeroes(1,1,0))->dims], [1,1,0]; # used to segfault
 
+{
+no warnings 'once';
+is *::plus{CODE}, undef, 'plus not exported';
+is *::mult{CODE}, undef, 'mult not exported';
+is *::minus{CODE}, undef, 'minus not exported';
+is *::divide{CODE}, undef, 'divide not exported';
+is *::gt{CODE}, undef, 'gt not exported';
+is *::lt{CODE}, undef, 'lt not exported';
+is *::le{CODE}, undef, 'le not exported';
+is *::ge{CODE}, undef, 'ge not exported';
+is *::eq{CODE}, undef, 'eq not exported';
+is *::ne{CODE}, undef, 'ne not exported';
+is *::shiftleft{CODE}, undef, 'shiftleft not exported';
+is *::shiftright{CODE}, undef, 'shiftright not exported';
+is *::or2{CODE}, undef, 'or2 not exported';
+is *::and2{CODE}, undef, 'and2 not exported';
+is *::xor{CODE}, undef, 'xor not exported';
+is *::bitnot{CODE}, undef, 'bitnot not exported';
+is *::power{CODE}, undef, 'power not exported';
+is *::atan2{CODE}, undef, 'atan2 not exported';
+is *::modulo{CODE}, undef, 'modulo not exported';
+is *::spaceship{CODE}, undef, 'spaceship not exported';
+is *::sqrt{CODE}, undef, 'sqrt not exported';
+is *::sin{CODE}, undef, 'sin not exported';
+is *::cos{CODE}, undef, 'cos not exported';
+is *::not{CODE}, undef, 'not not exported';
+is *::exp{CODE}, undef, 'exp not exported';
+is *::log{CODE}, undef, 'log not exported';
+ok defined(*::log10{CODE}), 'log10 exported';
+is *::_rabs{CODE}, undef, '_rabs not exported';
+ok defined(*::assgn{CODE}), 'assgn exported';
+ok defined(*::carg{CODE}), 'carg exported';
+ok defined(*::conj{CODE}), 'conj exported';
+is *::re{CODE}, undef, 're not exported';
+is *::im{CODE}, undef, 'im not exported';
+is *::_cabs{CODE}, undef, '_cabs not exported';
+ok defined(*::czip{CODE}), 'czip exported';
+ok defined(*::ipow{CODE}), 'ipow exported';
+ok defined(*::abs2{CODE}), 'abs2 exported';
+ok defined(*::r2C{CODE}), 'r2C exported';
+ok defined(*::i2C{CODE}), 'i2C exported';
+}
+
 done_testing;

--- a/t/pp_pod.t
+++ b/t/pp_pod.t
@@ -32,9 +32,35 @@ subtest a => sub {
     my $obj = call_pp_def(foo =>
         Pars => 'a(n)',
     );
-
     ok find_usage($obj, 'foo($a)'), 'function call';
     ok find_usage($obj, '$a->foo'), 'method call';
+    ok all_seen($obj, 'foo'), 'all seen';
+};
+
+subtest a_n => sub {
+    my $obj = call_pp_def(foo =>
+        Pars => 'a(n)',
+        NoExport => 1,
+    );
+    ok find_usage($obj, '$a->foo'), 'method call';
+    ok find_usage($obj, 'Foo::Bar::foo($a)'), 'no-exp function call';
+    ok all_seen($obj, 'foo'), 'all seen';
+};
+
+subtest a_b_noi => sub {
+    my $obj = call_pp_def(foo =>
+        Pars => 'a(n); [o]b(n)',
+        NoExport => 1,
+        Overload => ['foo', 1],
+        Inplace => ['a'],
+    );
+    ok find_usage($obj, '$b = foo $a'), 'operator';
+    ok find_usage($obj, '$b = $a->foo'), 'method call';
+    ok find_usage($obj, '$a->foo($b)'), 'method, all args';
+    ok find_usage($obj, '$a->inplace->foo'), 'method, inplace';
+    ok find_usage($obj, '$b = Foo::Bar::foo($a)'), 'function call';
+    ok find_usage($obj, 'Foo::Bar::foo($a, $b)'), 'all args';
+    ok find_usage($obj, 'Foo::Bar::foo($a->inplace)'), 'function, inplace';
     ok all_seen($obj, 'foo'), 'all seen';
 };
 
@@ -58,7 +84,6 @@ subtest a_b => sub {
     my $obj = call_pp_def(foo =>
       Pars => 'a(n); [o]b(n)',
     );
-
     ok find_usage($obj, '$b = foo($a)'), 'function call w/ arg';
     ok find_usage($obj, 'foo($a, $b)'), 'all arguments given';
     ok find_usage($obj, '$b = $a->foo'), 'method call';
@@ -71,7 +96,6 @@ subtest a_b_k => sub {
         Pars => 'a(n); [o]b(n)',
         OtherPars => 'int k',
     );
-
     ok find_usage($obj, '$b = foo($a, $k)'), 'function call w/ arg';
     ok find_usage($obj, 'foo($a, $b, $k)'), 'all arguments given';
     ok find_usage($obj, '$b = $a->foo($k)'), 'method call';
@@ -84,7 +108,6 @@ subtest ab_c_o => sub {
         Pars => 'a(n); b(n); [o]c(n)',
         Overload => '?:',
     );
-
     ok find_usage($obj, '$c = $a ?: $b'), 'biop';
     ok find_usage($obj, '$c = foo($a, $b)'), 'function';
     ok find_usage($obj, 'foo($a, $b, $c)'), 'function, all args';
@@ -99,7 +122,6 @@ subtest ab_c_oi => sub {
         Overload => ['?:', 1],
         Inplace => ['a'],
     );
-
     ok find_usage($obj, '$c = $a ?: $b'), 'biop';
     ok find_usage($obj, '$c = foo($a, $b)'), 'function';
     ok find_usage($obj, 'foo($a, $b, $c)'), 'function, all args';
@@ -111,12 +133,26 @@ subtest ab_c_oi => sub {
     ok all_seen($obj, 'foo'), 'all seen';
 };
 
+subtest ab_c_ni => sub {
+    my $obj = call_pp_def(foo =>
+        Pars => 'a(n); b(n); [o]c(n)',
+        Inplace => ['a'],
+        NoExport => 1,
+    );
+    ok find_usage($obj, '$c = Foo::Bar::foo($a, $b)'), 'function';
+    ok find_usage($obj, '$c = $a->foo($b)'), 'method';
+    ok find_usage($obj, '$a->foo($b, $c)'), 'method, all args';
+    ok find_usage($obj, '$a->inplace->foo($b)'), 'inplace method call';
+    ok find_usage($obj, 'Foo::Bar::foo($a, $b, $c)'), 'function, all args';
+    ok find_usage($obj, 'Foo::Bar::foo($a->inplace, $b)'), 'inplace function call';
+    ok all_seen($obj, 'foo'), 'all seen';
+};
+
 subtest ab_c_o => sub {
     my $obj = call_pp_def(foo =>
         Pars => 'a(n); b(n); [o]c(n)',
         Overload => ['rho'],
     );
-
     ok find_usage($obj, '$c = foo($a, $b)'), 'function';
     ok find_usage($obj, 'foo($a, $b, $c)'), 'function, all args';
     ok find_usage($obj, '$c = $a->foo($b)'), 'method';
@@ -125,11 +161,25 @@ subtest ab_c_o => sub {
     ok all_seen($obj, 'foo'), 'all seen';
 };
 
+subtest ab_c_no => sub {
+    my $obj = call_pp_def(foo =>
+        Pars => 'a(n); b(n); [o]c(n)',
+        Overload => ['rho', 0, 0, 1],
+        NoExport => 1,
+    );
+    ok find_usage($obj, '$c = rho $a, $b'), 'prefix biop';
+    ok find_usage($obj, '$c = $a->foo($b)'), 'method';
+    ok find_usage($obj, '$a->foo($b, $c)'), 'method, all args';
+    ok find_usage($obj, '$c = Foo::Bar::foo($a, $b)'), 'function';
+    ok find_usage($obj, 'Foo::Bar::foo($a, $b, $c)'), 'function, all args';
+    ok all_seen($obj, 'foo'), 'all seen';
+};
+
+
 subtest a_bc => sub {
     my $obj = call_pp_def(foo =>
         Pars => 'a(n); [o]b(n); [o]c(n)',
     );
-
     ok find_usage($obj, 'foo($a, $b, $c)'), 'multi output function call, all args';
     ok find_usage($obj, '($b, $c) = foo($a)'), 'multi output function call';
     ok find_usage($obj, '($b, $c) = $a->foo'), 'multi output method call';
@@ -143,7 +193,6 @@ subtest ab_k_c => sub {
         OtherPars => 'int k',
         ArgOrder => [qw(a b k c)],
     );
-
     ok find_usage($obj, 'foo($a, $b, $k, $c)'), 'OtherPars, ArgOrder, function call, all args';
     ok find_usage($obj, '$c = $a->foo($b, $k)'), 'OtherPars, ArgOrder, method call';
     ok find_usage($obj, '$a->foo($b, $k, $c)'), 'OtherPars, ArgOrder, method call, all args';
@@ -169,7 +218,6 @@ subtest ab_k_cd => sub {
         OtherPars => 'int k',
         ArgOrder => [qw(a b k c d)],
     );
-
     ok find_usage($obj, 'foo($a, $b, $k, $c, $d)'), 'Multi-out, OtherPars, ArgOrder, function call, all args';
     ok find_usage($obj, '($c, $d) = $a->foo($b, $k)'), 'Multi-out, OtherPars, ArgOrder, method call';
     ok find_usage($obj, '$a->foo($b, $k, $c, $d)'), 'Multi-out, OtherPars, ArgOrder, method call, all args';
@@ -182,7 +230,6 @@ subtest ab_cd_k => sub {
         Pars => 'a(n); b(n); [o]c(n); [o]d(n)',
         OtherPars => 'int k',
     );
-
     ok find_usage($obj, 'foo($a, $b, $c, $d, $k)'), 'Multi-out, OtherPars, function call, all args';
     ok find_usage($obj, '($c, $d) = $a->foo($b, $k)'), 'Multi-out, OtherPars, method call';
     ok find_usage($obj, '$a->foo($b, $c, $d, $k)'), 'Multi-out, OtherPars, method call, all args';


### PR DESCRIPTION
Please excuse me for being so stubborn and tedious. I become obsessed with an idea too easily.

This patch provides an option `CallFQ` to `pp_def` that makes function calls in the generated POD's usage section fully qualified.

I was merely trying to find out if I could do that. Then it turned out it was much easier than I expected.