### PR TITLE
Change magnover so magnitude of complex is real

### DIFF
--- a/lib/PDL/Ufunc.pd
+++ b/lib/PDL/Ufunc.pd
@@ -1242,8 +1242,8 @@ for L</qsortvec>.
 
 pp_def('magnover',
   HandleBad => 1,
-  Pars => "a(n); float+ [o]b();",
-  GenericTypes => $A,
+  Pars => "a(n); real [o]b();",
+  GenericTypes => [qw(H C G E D F)],
   Code => <<'EOF',
 long double sum=0;
 PDL_IF_BAD(int flag = 0;,)

--- a/t/ufunc.t
+++ b/t/ufunc.t
@@ -103,7 +103,7 @@ is_pdl $empty->magnover, float('BAD'), "bad flag gets set on empty magnover";
 
 is_pdl zeroes(4)->magnover, pdl(0), 'magnover correct for real zeroes';
 is_pdl sequence(4)->magnover, pdl(3.741657), 'magnover correct for real sequence';
-is_pdl +(sequence(4)+i())->magnover, cdouble(4.242640), 'magnover correct for complex';
+is_pdl +(sequence(4)+i())->magnover, double(4.242640), 'magnover correct for complex';
 
 #Test subroutines directly.
 


### PR DESCRIPTION
I followed a suggestion by Jörg Sommrey. The magnitude of integer vectors should be floating point, but that of complex vectors should be real. The actual float+ output specification yields complex magnitudes (with 0 imaginary part) for complex vectors. I guess the problem with the solution proposed here is that integer vectors may be converted to float vectors before the magnitude is computed, probably  wasting space. 